### PR TITLE
Create TypeNode abstraction

### DIFF
--- a/src/ast-helpers.ts
+++ b/src/ast-helpers.ts
@@ -47,7 +47,7 @@ export function toOptional(option: string = '') {
   }
 }
 
-export type Container = { name: string, keyType?: string, valueType: string};
+export type Container = { name: string, keyType?: string | Container, valueType: string | Container };
 export type Typedef = string | Container;
 
 export function toAstType(typedef: Typedef) : ts.TypeNode {

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,10 +25,14 @@ import {
 
 import {
   resolveStructs,
-  resolveTypes,
   resolveNamespace,
   resolveInterfaces
 } from './resolve';
+import {
+  Typedefs,
+  TypeNode,
+  resolveTypes,
+} from './resolve/typedefs';
 import {
   validateTypes,
   validateStructs
@@ -287,11 +291,11 @@ function createWrite(service) {
   return ts.createMethod(undefined, [_tokens.public], undefined, _id.write, undefined, undefined, [_outputDeclaration], undefined, _writeBlock);
 }
 
-interface ResolvedTypedef {
-  name: string,
-  type: string,
-  originalType: string
-}
+// interface ResolvedTypedef {
+//   name: string,
+//   type: string,
+//   originalType: string
+// }
 
 interface ResolvedStruct {
   name: string,
@@ -319,7 +323,7 @@ type ResolvedNamespace = string;
 
 interface ResolvedIDL {
   namespace?: ResolvedNamespace,
-  typedefs: ResolvedTypedef[],
+  typedefs: Typedefs,
   interfaces: ResolvedInterface[],
   structs: ResolvedStruct[],
 }
@@ -368,11 +372,7 @@ function generateTypesAST(idl: ResolvedIDL): string {
     _require
   ]);
 
-  const _types = idl.typedefs.map(function(typedef) {
-    const _type = ts.createTypeAliasDeclaration(undefined, [_tokens.export], typedef.name, undefined, toAstType(typedef.type));
-
-    return _type;
-  });
+  const _types = idl.typedefs.toAST();
 
   const _interfaces = idl.interfaces.map(function(iface) {
     const _interfaceName = ts.createIdentifier(iface.name);
@@ -456,7 +456,8 @@ export async function generateIDLTypes(filename: string): Promise<string> {
 
   // Non-mutation
   const typedefs = resolveTypes(idl);
-  validateTypes(typedefs);
+  // Currently moved to InvalidTypeNode
+  // validateTypes(typedefs);
 
   const interfaces = resolveInterfaces(idl);
   // TODO: validate interfaces

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -1,7 +1,4 @@
-import {
-  getStructs,
-  getTypeDefs
-} from './get';
+import { getStructs } from './get';
 
 function isBaseType(type: string) {
   const baseTypes = ['bool', 'byte', 'i8', 'i16', 'i32', 'i64', 'double', 'string', 'binary', 'slist'];
@@ -41,22 +38,6 @@ function resolveType(idl, type: string) {
   }
 
   return;
-}
-
-export function resolveTypes(idl) {
-  const typedefs = getTypeDefs(idl);
-
-  return typedefs.map((typedef) => {
-    const { name, type } = typedef;
-
-    let resolvedType = resolveType(idl, type);
-
-    return {
-      name: name,
-      type: resolvedType,
-      originalType: type
-    };
-  });
 }
 
 export function resolveStructs(idl) {

--- a/src/resolve/typedefs.ts
+++ b/src/resolve/typedefs.ts
@@ -1,0 +1,172 @@
+import {
+  createTypeAliasDeclaration,
+  createKeywordTypeNode,
+  createTypeReferenceNode,
+  createArrayTypeNode,
+
+  SyntaxKind,
+
+  TypeAliasDeclaration,
+  KeywordTypeNode,
+  TypeReferenceNode,
+  ArrayTypeNode
+} from 'typescript';
+
+
+import { getTypeDefs } from '../get';
+import { tokens as _tokens } from '../ast/tokens';
+
+export class Typedefs {
+  public entries: TypeNode[];
+
+  constructor(entries) {
+    this.entries = entries;
+  }
+
+  public toAST(): TypeAliasDeclaration[] {
+    return this.entries.map((typedef) => {
+      return createTypeAliasDeclaration(undefined, [_tokens.export], typedef.name, undefined, typedef.toAST());
+    });
+  }
+}
+
+export class BaseTypeNode {
+  public name: string;
+
+  constructor(name) {
+    this.name = name;
+  }
+
+  public toAST(): KeywordTypeNode | TypeReferenceNode {
+    switch(this.name.toUpperCase()) {
+      case 'BOOL':
+        return createKeywordTypeNode(SyntaxKind.BooleanKeyword);
+      case 'BYTE': // TODO: is this a number type?
+      case 'I08': // TODO: is this a number type?
+      case 'DOUBLE':
+      case 'I16':
+      case 'I32':
+      case 'I64':
+        return createKeywordTypeNode(SyntaxKind.NumberKeyword);
+      case 'STRING':
+      case 'UTF7':
+      case 'UTF8':
+      case 'UTF16':
+        return createKeywordTypeNode(SyntaxKind.StringKeyword);
+      case 'VOID': // TODO: does this need a type?
+        throw new Error('Not Implemented');
+      // case 'STRUCT': // TODO: this is handed down as a custom type, is it needed?
+      //   return ts.createTypeReferenceNode(this.name, undefined);
+      default:
+        return createTypeReferenceNode(this.name, undefined);
+    }
+  }
+}
+
+export class TypeNode {
+  public name: string;
+  public keyType?: BaseTypeNode | TypeNode;
+  public valueType: BaseTypeNode | TypeNode;
+
+  constructor(args) {
+    this.name = args.name;
+    this.keyType = args.keyType;
+    this.valueType = args.valueType;
+  }
+
+  public toAST(): TypeReferenceNode | ArrayTypeNode | KeywordTypeNode {
+    switch(this.name.toUpperCase()) {
+      // case 'STRUCT': {
+        // TODO: this is handed down as a custom type, is it needed?
+        // return createTypeReferenceNode(this.valueType.toAST(), undefined);
+      // }
+      case 'MAP': {
+        // TODO: _id.Map
+        return createTypeReferenceNode('Map', [this.keyType.toAST(), this.valueType.toAST()]);
+      }
+      case 'LIST': {
+        return createArrayTypeNode(this.valueType.toAST());
+      }
+      case 'SET': {
+        // TODO: _id.Set
+        return createTypeReferenceNode('Set', [this.valueType.toAST()]);
+      }
+      default:
+        return this.valueType.toAST();
+    }
+  }
+}
+
+export class InvalidTypeNode {
+  public name: string;
+
+  constructor(name) {
+    this.name = name;
+  }
+
+  toAST() {
+    throw new Error(`Unable to find typedef: ${this.name}`);
+  }
+}
+
+function isBaseType(type: string) {
+  const baseTypes = ['bool', 'byte', 'i8', 'i16', 'i32', 'i64', 'double', 'string', 'binary', 'slist'];
+
+  // Why doesn't typescript define .includes?
+  return (baseTypes.indexOf(type) !== -1);
+}
+
+function isContainerType(type: string) {
+  const containerTypes = ['map', 'set', 'list'];
+
+  return (containerTypes.indexOf(type) !== -1);
+}
+
+function resolveTypeNode(idl, type) {
+  if (isBaseType(type)) {
+    return new BaseTypeNode(type);
+  }
+
+  if (isContainerType(type.name)) {
+    return new TypeNode({
+      name: type.name,
+      keyType: resolveTypeNode(idl, type.keyType),
+      valueType: resolveTypeNode(idl, type.valueType),
+    });
+  }
+
+  if (idl.typedef[type]) {
+    return new TypeNode({
+      name: type,
+      valueType: resolveTypeNode(idl, idl.typedef[type].type)
+    });
+  }
+
+  if (idl.struct[type]) {
+    return new TypeNode({
+      name: 'struct',
+      valueType: new BaseTypeNode(type)
+    });
+  }
+
+  // TODO: does validation belong in here?
+  return new InvalidTypeNode(type);
+}
+
+
+export function resolveTypes(idl) {
+  const typedefs = getTypeDefs(idl);
+
+  const entries = typedefs.map((typedef) => {
+    const { name, type } = typedef;
+
+    const entry = new TypeNode({
+      name: name,
+      valueType: resolveTypeNode(idl, type)
+    });
+
+    return entry;
+  });
+
+  return new Typedefs(entries);
+}


### PR DESCRIPTION
This PR implements classes to store information for `Typedef`, `BaseTypeNode` (string, boolean, etc), `TypeNode` (containers, custom types, etc), and `InvalidTypeNode` (used for validation purposes).  Each class exposes a `toAST` method that can be traversed into children to fully resolve a type to a `BaseTypeNode`

It also exposes a `resolveTypeNode` method to recursively resolve a nested type into linked `TypeNode` instances & a `resolveTypes` method to resolve a list of `typedefs` into a `Typedef` instance.

This code is further modified in later PRs to better support reuse and better define each node.