### PR TITLE
Introduce Interface node abstraction

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,14 +25,17 @@ import {
 
 import {
   resolveStructs,
-  resolveNamespace,
-  resolveInterfaces
+  resolveNamespace
 } from './resolve';
 import {
-  Typedefs,
+  Typedef,
   TypeNode,
   resolveTypes,
 } from './resolve/typedefs';
+import {
+  Interface,
+  resolveInterfaces
+} from './resolve/interfaces';
 import {
   validateTypes,
   validateStructs
@@ -297,11 +300,6 @@ interface ResolvedStruct {
   fields: ResolvedField[]
 }
 
-interface ResolvedInterface {
-  name: string,
-  fields: ResolvedFieldBase[]
-}
-
 interface ResolvedFieldBase {
   name: string,
   type: string | any, // TODO: objects/Typedef
@@ -317,8 +315,8 @@ type ResolvedNamespace = string;
 
 interface ResolvedIDL {
   namespace?: ResolvedNamespace,
-  typedefs: Typedefs,
-  interfaces: ResolvedInterface[],
+  typedefs: Typedef[],
+  interfaces: Interface[],
   structs: ResolvedStruct[],
 }
 
@@ -366,17 +364,9 @@ function generateTypesAST(idl: ResolvedIDL): string {
     _require
   ]);
 
-  const _types = idl.typedefs.toAST();
+  const _types = idl.typedefs.map((typedef) => typedef.toAST());
 
-  const _interfaces = idl.interfaces.map(function(iface) {
-    const _interfaceName = ts.createIdentifier(iface.name);
-
-    const _fieldSignatures = iface.fields.map(createFieldSignature);
-
-    const _interface = ts.createInterfaceDeclaration(undefined, [_tokens.export], _interfaceName, [], [], _fieldSignatures);
-
-    return _interface;
-  });
+  const _interfaces = idl.interfaces.map((iface) => iface.toAST());
 
   const _structs = idl.structs.map(function(struct) {
 

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -82,25 +82,3 @@ export function resolveNamespace(idl) {
     return idl.namespace[scope].serviceName;
   }
 }
-
-export function resolveInterfaces(idl) {
-  const structs = getStructs(idl);
-
-  return structs.map((struct) => {
-    const { name } = struct;
-
-    const fields = [{name: 'success', type: 'boolean'}].concat(struct.fields)
-      .map((field: { name: string, type: string | any, option?: string }) => {
-        return {
-          name: field.name,
-          type: field.type,
-          option: field.option
-        };
-      });
-
-    return {
-      name: `${name}Interface`,
-      fields: fields
-    };
-  });
-}

--- a/src/resolve/interfaces.ts
+++ b/src/resolve/interfaces.ts
@@ -1,0 +1,82 @@
+import {
+  createInterfaceDeclaration,
+  createPropertySignature,
+
+  InterfaceDeclaration,
+  PropertySignature
+} from 'typescript'
+
+import {
+  TypeNode,
+  resolveTypeNode
+} from './typedefs'
+
+import {
+  getStructs
+} from '../get';
+
+import {
+  toOptional
+} from '../ast-helpers';
+
+import {
+  tokens
+} from '../ast/tokens';
+
+export class InterfacePropertyNode {
+  public name: string;
+  public type: TypeNode;
+  public option?: string;
+
+  constructor(args) {
+    console.log(args);
+    this.name = args.name;
+    this.type = args.type;
+    this.option = args.option;
+  }
+
+  public toAST(): PropertySignature {
+    let _type = this.type.toAST();
+    let _optional = toOptional(this.option);
+
+    return createPropertySignature(undefined, this.name, _optional, _type, undefined);
+  }
+}
+
+export class Interface {
+  public name: string;
+  public fields: InterfacePropertyNode[];
+
+  constructor(args) {
+    this.name = args.name;
+    this.fields = args.fields;
+  }
+
+  public toAST(): InterfaceDeclaration {
+    const signatures = this.fields.map((field) => field.toAST());
+
+    return createInterfaceDeclaration(undefined, [tokens.export], this.name, [], [], signatures);
+  }
+}
+
+export function resolveInterfaces(idl) {
+  const structs = getStructs(idl);
+
+  return structs.map((struct) => {
+    const { name } = struct;
+
+    const fields = [{name: 'success', type: 'bool'}].concat(struct.fields)
+      .map((field: { name: string, type: string, option?: string}) => {
+        return new InterfacePropertyNode({
+          name: field.name,
+          option: field.option,
+          type: resolveTypeNode(idl, field.type)
+        });
+      });
+
+    return new Interface({
+      name: `${name}Interface`,
+      fields: fields
+    });
+  });
+}


### PR DESCRIPTION
This PR introduces similar logic to the TypeNode abstraction but for Interfaces.  Interfaces use TypeNodes to track their types but to make that possible, TypeNodes needed a slight refactor and they needed to be contained within a Typedef node when used as type aliases.

(Note: TypeNodes got yet-another refactor yesterday that clean them up considerably.)