### PR TITLE
Map namespaces and IDLs to custom types

### DIFF
--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -1,9 +1,0 @@
-
-export function resolveNamespace(idl) {
-  // TODO: the parser doesn't parse dot-separated namespaces
-  const scope = 'js';
-
-  if (idl.namespace && idl.namespace[scope]) {
-    return idl.namespace[scope].serviceName;
-  }
-}

--- a/src/resolve/idls.ts
+++ b/src/resolve/idls.ts
@@ -1,0 +1,50 @@
+import {
+  createModuleBlock,
+  createModuleDeclaration,
+
+  NodeFlags,
+
+  ModuleDeclaration
+} from 'typescript';
+
+import { NamespaceNode, resolveNamespace } from './namespace';
+import { TypedefNode, resolveTypedefs } from './typedefs';
+import { InterfaceNode, resolveInterfaces } from './interfaces';
+import { StructNode, resolveStructs } from './structs';
+
+import { tokens } from '../ast/tokens';
+
+export class IDLNode {
+  public filename: string;
+  public namespace: NamespaceNode
+  public typedefs: TypedefNode[];
+  public interfaces: InterfaceNode[];
+  public structs: StructNode[];
+
+  constructor(idl) {
+    // TODO: are the `resolve` methods better served in the constructor or resolveIDLs?
+    this.namespace = resolveNamespace(idl);
+    this.typedefs = resolveTypedefs(idl);
+    this.interfaces = resolveInterfaces(idl);
+    this.structs = resolveStructs(idl);
+  }
+
+  public toAST(): ModuleDeclaration {
+    const namespace = this.namespace.toAST();
+    const types = this.typedefs.map((typedef) => typedef.toAST());
+    const interfaces = this.interfaces.map((iface) => iface.toAST());
+    const structs = this.structs.map((struct) => struct.toAST());
+
+    const _namespaceBlock = createModuleBlock([
+      ...types,
+      ...interfaces,
+      ...structs
+    ]);
+
+    return createModuleDeclaration(undefined, [tokens.export], namespace, _namespaceBlock, NodeFlags.Namespace);
+  }
+}
+
+export function resolveIDLs(idls: any[]) {
+  return idls.map((idl) => new IDLNode(idl))
+}

--- a/src/resolve/namespace.ts
+++ b/src/resolve/namespace.ts
@@ -1,0 +1,36 @@
+import { basename, extname } from 'path';
+
+import { createIdentifier, Identifier } from 'typescript';
+
+export class NamespaceNode {
+  // TODO: handle other namespaces
+  // public scope: string;
+  public name: string;
+
+  constructor(name) {
+    this.name = name;
+  }
+
+  public toAST(): Identifier {
+    return createIdentifier(this.name);
+  }
+}
+
+export function resolveNamespace(idl) {
+  // TODO: the parser doesn't parse dot-separated namespaces
+  const scope = 'js';
+
+  if (idl.namespace && idl.namespace[scope]) {
+    const namespace = idl.namespace[scope].serviceName;
+    return new NamespaceNode(namespace);
+  } else {
+    let namespace = basename(idl.filename, extname(idl.filename));
+    if (namespace) {
+      namespace = namespace[0].toUpperCase() + namespace.slice(1);
+    } else {
+      // TODO: invalid node?
+      throw new Error('not a namespace');
+    }
+    return new NamespaceNode(namespace);
+  }
+}


### PR DESCRIPTION
This PR applies the Node abstraction to the IDL and namespaces.  These abstractions move us closer to resolving `includes` (which, I believe, is the next PR I will be submitting).