### PR TITLE
Add ConstNode & ValueNode abstractions

### DIFF
--- a/fixtures/complex.thrift
+++ b/fixtures/complex.thrift
@@ -1,12 +1,51 @@
+include 'simple'
+
 namespace js MyThing
 
 typedef string Json
 typedef i32 MyInteger
 typedef CustomJson NestedJson
 typedef Json CustomJson
+typedef map<string, string> CustomMap
+typedef Embed myEmbed
+// typedef whoops partial
 // typedef NotDefined whoops
 
+const bool FALSE_CONST = false
+const bool TRUE_CONST = true
+const byte BYTE_CONST = 1
+const i8 I8_CONST = 1
+const double DOUBLE_CONST = 1.2
+const i16 I16_CONST = 123
+const i32 I32_CONST = 123
+const i64 I64_CONST = 123
+const string STRING_CONST = 'test'
+// Containers
+const set<string> SET_CONST = ['hello', 'world', 'foo', 'bar']
+const set<set<string>> SET_SET_CONST = [['hello', 'world'], ['foo', 'bar']]
+const list<string> LIST_CONST = ['hello', 'world', 'foo', 'bar']
+const list<list<string>> LIST_LIST_CONST = [['hello', 'world'], ['foo', 'bar']]
+const list<set<string>> LIST_SET_CONST = [['hello', 'world'], ['foo', 'bar']]
+const set<list<string>> SET_LIST_CONST = [['hello', 'world'], ['foo', 'bar']]
+const map<string,string> MAP_CONST = {'hello': 'world'}
+const map<i16, map<string,string>> MAP_MAP_CONST = {123: {'hello': 'world'}}
+const list<set<map<string,string>>> LIST_SET_MAP_CONST = [[{'hello': 'world'}, {'foo': 'bar'}]]
+// Type Aliases
+const Json ALIAS_CONST = 'test'
+const CustomMap CONTAINER_ALIAS_CONST = {'hello': 'world'}
+// Structs
+const Basic STRUCT_CONST = {'name': 'blaine'}
+const WithContainers CONTAINER_STRUCT_CONST = {'map': {'hello': 'world'}}
+
 struct Embed {}
+
+struct Basic {
+    1: string name
+}
+
+struct WithContainers {
+    1: map<string, string> map
+}
 
 struct MyStruct {
     1: required i32 id,

--- a/src/get.ts
+++ b/src/get.ts
@@ -4,6 +4,17 @@ export function getTypeDefs(idl: any) {
   return Object.keys(typedefs).map(key => Object.assign({ name: key}, typedefs[key]));
 }
 
+export function getConstants(idl: any) {
+  const constants = idl.const || {};
+  return Object.keys(constants).map((key) => {
+    return {
+      name: key,
+      type: constants[key].type,
+      value: constants[key].value
+    };
+  });
+}
+
 export function getStructs(idl: any) {
   const structs = idl.struct || {};
   return Object.keys(structs).map(key => ({

--- a/src/resolve/consts.ts
+++ b/src/resolve/consts.ts
@@ -1,0 +1,47 @@
+import {
+  createVariableStatement,
+  createVariableDeclaration,
+  createVariableDeclarationList,
+
+  NodeFlags,
+
+  VariableStatement
+} from 'typescript';
+
+import { TypeNode, resolveTypeNode } from './typedefs';
+import { ValueNode, resolveValueNode } from './values';
+
+import { tokens } from '../ast/tokens';
+import { getConstants } from '../get';
+
+export class ConstNode {
+  public name: string;
+  public type: TypeNode;
+  public value: ValueNode;
+
+  constructor(args) {
+    this.name = args.name;
+    this.type = args.type;
+    this.value = args.value;
+  }
+
+  public toAST(): VariableStatement {
+    const _const = createVariableDeclaration(this.name, this.type.toAST(), this.value.toAST());
+
+    const _constList = createVariableDeclarationList([_const], NodeFlags.Const);
+
+    return createVariableStatement([tokens.export], _constList);
+  }
+}
+
+export function resolveConsts(idl) {
+  const constants = getConstants(idl);
+
+  return constants.map((constant) => {
+    return new ConstNode({
+      name: constant.name,
+      type: resolveTypeNode(idl, constant.type),
+      value: resolveValueNode(idl, constant.type, constant.value)
+    });
+  });
+}

--- a/src/resolve/idls.ts
+++ b/src/resolve/idls.ts
@@ -10,6 +10,7 @@ import {
 } from 'typescript';
 
 import { NamespaceNode, resolveNamespace } from './namespace';
+import { ConstNode, resolveConsts } from './consts';
 import { TypedefNode, resolveTypedefs } from './typedefs';
 import { InterfaceNode, resolveInterfaces } from './interfaces';
 import { StructNode, resolveStructs } from './structs';
@@ -18,8 +19,9 @@ import { tokens } from '../ast/tokens';
 
 export class IDLNode {
   public filename: string;
-  public namespace: NamespaceNode
+  public namespace: NamespaceNode;
   public typedefs: TypedefNode[];
+  public consts: ConstNode[];
   public interfaces: InterfaceNode[];
   public structs: StructNode[];
 
@@ -28,6 +30,7 @@ export class IDLNode {
     // TODO: are the `resolve` methods better served in the constructor or resolveIDLs?
     this.namespace = resolveNamespace(idl);
     this.typedefs = resolveTypedefs(idl);
+    this.consts = resolveConsts(idl);
     this.interfaces = resolveInterfaces(idl);
     this.structs = resolveStructs(idl);
   }
@@ -35,13 +38,15 @@ export class IDLNode {
   public toAST(): ModuleDeclaration {
     const namespace = this.namespace.toAST();
     const types = this.typedefs.map((typedef) => typedef.toAST());
+    const constants = this.consts.map((constant) => constant.toAST());
     const interfaces = this.interfaces.map((iface) => iface.toAST());
     const structs = this.structs.map((struct) => struct.toAST());
 
     let namespaceBlock = createModuleBlock([
       ...types,
       ...interfaces,
-      ...structs
+      ...structs,
+      ...constants
     ]);
 
     let moduleDec = createModuleDeclaration(undefined, [tokens.export], namespace, namespaceBlock, NodeFlags.Namespace);

--- a/src/resolve/values.ts
+++ b/src/resolve/values.ts
@@ -1,0 +1,151 @@
+import {
+  createLiteral,
+  createNew,
+  createArrayLiteral,
+
+  createIdentifier,
+
+  createPropertyAssignment,
+  createObjectLiteral,
+
+  PrimaryExpression,
+  NewExpression,
+  ArrayLiteralExpression
+} from 'typescript';
+
+import { isBaseType, isListLikeType, isSetLikeType, isMapLikeType } from '../is';
+import { identifiers as _id } from '../ast/identifiers';
+
+export type ValueNode = BaseValueNode | StructValueNode | MapValueNode | SetValueNode | ListValueNode;
+
+export class BaseValueNode {
+  public value: string | number | boolean;
+
+  constructor(value) {
+    this.value = value;
+  }
+
+  public toAST(): PrimaryExpression {
+    return createLiteral(this.value);
+  }
+}
+
+export class StructValueNode {
+  public name: string;
+  public values: any[];
+
+  constructor(args) {
+    this.name = args.name;
+    this.values = args.values;
+  }
+
+  public toAST(): NewExpression {
+    const id = createIdentifier(this.name);
+    const values = this.values.map((val) => {
+      console.log(val);
+      return createPropertyAssignment(val.key, val.value.toAST())
+    });
+    return createNew(id, undefined, [createObjectLiteral(values)]);
+  }
+}
+
+export class ListValueNode {
+  public values: ValueNode[];
+
+  constructor(values) {
+    this.values = values;
+  }
+
+  public toAST(): ArrayLiteralExpression {
+    const values = this.values.map((val) => val.toAST());
+    return createArrayLiteral(values);
+  }
+}
+
+export class SetValueNode {
+  public values: ValueNode[];
+
+  constructor(values) {
+    this.values = values;
+  }
+
+  public toAST(): NewExpression {
+    const values = this.values.map((val) => val.toAST());
+    return createNew(_id.Set, undefined, [createArrayLiteral(values)]);
+  }
+}
+
+export class MapValueNode {
+  public values: { key: ValueNode, value: ValueNode }[];
+
+  constructor(values) {
+    this.values = values;
+  }
+
+  public toAST(): NewExpression {
+    const values = this.values.map((tuple) => {
+      return createArrayLiteral([tuple.key.toAST(), tuple.value.toAST()])
+    });
+    return createNew(_id.Map, undefined, [createArrayLiteral(values)]);
+  }
+}
+
+export class InvalidValueNode {
+  public value: any;
+
+  constructor(value) {
+    this.value = value
+  }
+
+  public toAST() {
+    throw new Error(`Invalid value: ${this.value}`);
+  }
+}
+
+export function resolveValueNode(idl, type, value) {
+  if (isBaseType(type)) {
+    return new BaseValueNode(value);
+  }
+
+  if (isMapLikeType(type)) {
+    const values = value.map((tuple) => {
+      return {
+        key: resolveValueNode(idl, type.keyType, tuple.key),
+        value: resolveValueNode(idl, type.valueType, tuple.value)
+      }
+    });
+    return new MapValueNode(values);
+  }
+
+  if (isSetLikeType(type)) {
+    const values = value.map((val) => resolveValueNode(idl, type.valueType, val));
+    return new SetValueNode(values);
+  }
+
+  if (isListLikeType(type)) {
+    const values = value.map((val) => resolveValueNode(idl, type.valueType, val));
+    return new ListValueNode(values);
+  }
+
+  if (idl.typedef[type]) {
+    // We don't need a custom ValueNode type here, instead we can just resolve it to what it's supposed to be
+    return resolveValueNode(idl, idl.typedef[type].type, value);
+  }
+
+  if (idl.struct[type]) {
+    const values = value.map((tuple, idx) => {
+      // TODO: shouldn't be using idx and should lookup name, I think?
+      const fieldType = idl.struct[type][idx].type;
+      return {
+        key: tuple.key,
+        value: resolveValueNode(idl, fieldType, tuple.value)
+      };
+    });
+    return new StructValueNode({
+      name: type,
+      values: values
+    });
+  }
+
+  return new InvalidValueNode(value);
+}


### PR DESCRIPTION
This PR adds the Node abstraction for the `const` keyword and static values.  It also adds lots of sample cases in the `complex.thrift` file.  Further cleanup will be in upcoming PRs.