### PR TITLE
Initial thrift-parser typings

### DIFF
--- a/src/get.ts
+++ b/src/get.ts
@@ -1,7 +1,7 @@
 import collect from './collect';
 
 // TODO: Reduce complexity so this doesn't need to exist separately
-export function getInterfaces(idl: any) {
+export function getInterfaces(idl: JsonAST) {
   const unions = collect(idl.union);
   const structs = collect(idl.struct);
   const exceptions = collect(idl.exception);
@@ -15,7 +15,7 @@ export function getInterfaces(idl: any) {
 }
 
 // Still used by handlebars
-export function getStructs(idl: any) {
+export function getStructs(idl: JsonAST) {
   const structs = idl.struct || {};
   return Object.keys(structs).map(key => ({
     fields: structs[key],
@@ -24,7 +24,7 @@ export function getStructs(idl: any) {
 }
 
 // Still used by handlebars
-export function getServices(idl: any) {
+export function getServices(idl: JsonAST) {
   return Object.keys(idl.service).map(key => ({
     methods: idl.service[key].functions,
     name: key,

--- a/src/resolve/consts.ts
+++ b/src/resolve/consts.ts
@@ -34,7 +34,7 @@ export class ConstNode {
   }
 }
 
-export function resolveConsts(idl) {
+export function resolveConsts(idl: JsonAST) {
   const constants = collect(idl.const);
 
   return constants.map((constant) => {

--- a/src/resolve/exceptions.ts
+++ b/src/resolve/exceptions.ts
@@ -82,7 +82,7 @@ export class ExceptionNode extends StructNode {
   }
 }
 
-export function resolveExceptions(idl) {
+export function resolveExceptions(idl: JsonAST) {
   const exceptions = collect(idl.exception);
 
   return exceptions.map((exception) => {

--- a/src/resolve/idls.ts
+++ b/src/resolve/idls.ts
@@ -29,10 +29,10 @@ export class IDLNode {
   public unions: UnionNode[];
   public exceptions: ExceptionNode[];
 
-  constructor(idl) {
-    this.filename = idl.filename;
+  constructor(filename: string, idl: JsonAST) {
+    this.filename = filename;
     // TODO: are the `resolve` methods better served in the constructor or resolveIDLs?
-    this.namespace = resolveNamespace(idl);
+    this.namespace = resolveNamespace(idl, filename);
     this.typedefs = resolveTypedefs(idl);
     this.consts = resolveConsts(idl);
     this.interfaces = resolveInterfaces(idl);
@@ -68,6 +68,7 @@ export class IDLNode {
   }
 }
 
-export function resolveIDLs(idls: any[]) {
-  return idls.map((idl) => new IDLNode(idl))
+// TODO: IDLFile[]
+export function resolveIDLs(files: any[]) {
+  return files.map((file) => new IDLNode(file.filename, file.idl))
 }

--- a/src/resolve/interfaces.ts
+++ b/src/resolve/interfaces.ts
@@ -47,7 +47,7 @@ export class InterfaceNode {
   }
 }
 
-export function resolveInterfaces(idl) {
+export function resolveInterfaces(idl: JsonAST) {
   const interfaces = getInterfaces(idl);
 
   // TODO: This is a pretty hacky solution

--- a/src/resolve/namespace.ts
+++ b/src/resolve/namespace.ts
@@ -16,7 +16,8 @@ export class NamespaceNode {
   }
 }
 
-export function resolveNamespace(idl) {
+// TODO: IDL has filename attached
+export function resolveNamespace(idl: JsonAST, filename: string) {
   // TODO: the parser doesn't parse dot-separated namespaces
   const scope = 'js';
 
@@ -24,7 +25,7 @@ export function resolveNamespace(idl) {
     const namespace = idl.namespace[scope].serviceName;
     return new NamespaceNode(namespace);
   } else {
-    let namespace = basename(idl.filename, extname(idl.filename));
+    let namespace = basename(filename, extname(filename));
     return new NamespaceNode(namespace);
   }
 }

--- a/src/resolve/structs.ts
+++ b/src/resolve/structs.ts
@@ -114,7 +114,7 @@ export class StructNode {
   }
 }
 
-export function resolveStructs(idl) {
+export function resolveStructs(idl: JsonAST) {
   const structs = collect(idl.struct);
 
   return structs.map((struct) => {

--- a/src/resolve/typedefs.ts
+++ b/src/resolve/typedefs.ts
@@ -226,7 +226,7 @@ export function resolveTypeNode(idl, type) {
 }
 
 
-export function resolveTypedefs(idl) {
+export function resolveTypedefs(idl: JsonAST) {
   const typedefs = collect(idl.typedef);
 
   return typedefs.map((typedef) => {

--- a/src/resolve/unions.ts
+++ b/src/resolve/unions.ts
@@ -1,4 +1,3 @@
-
 import { resolveTypeNode } from './typedefs';
 import { StructNode, StructPropertyNode } from './structs';
 
@@ -20,7 +19,7 @@ export class UnionNode extends StructNode {
   // TODO: validate single default
 }
 
-export function resolveUnions(idl) {
+export function resolveUnions(idl: JsonAST) {
   const unions = collect(idl.union);
 
   return unions.map((union) => {

--- a/src/resolve/values.ts
+++ b/src/resolve/values.ts
@@ -102,7 +102,7 @@ export class InvalidValueNode {
   }
 }
 
-export function resolveValueNode(idl, type, value) {
+export function resolveValueNode(idl: JsonAST, type, value) {
   if (isBaseType(type)) {
     return new BaseValueNode(value);
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "removeComments": true,
     "types": [
       "@types/node",
-      "@types/mocha"
+      "@types/mocha",
+      "thrift-parser"
     ]
   },
   "exclude": [


### PR DESCRIPTION
This PR begins to add typings from the `thrift-parser` library into the project.  The 0.4.0 version is missing the union type (however, the 0.4.1 version has it but has a bug with complex container types that needs to be fixed).

More cleanup for these types will come in future PRs.