### PR TITLE
Bump thrift-parser to the patch with my fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "commander": "^2.9.0",
     "handlebars": "^4.0.5",
-    "thrift-parser": "0.4.0",
+    "thrift-parser": "^0.4.2",
     "typescript": "^2.4.0-dev.20170525"
   },
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
My fix has landed in a published version of thrift-parser.  Update to that minimum version.