### PR TITLE
Update namespace to look for js.ts (closes #15)

### DIFF
--- a/fixtures/complex.thrift
+++ b/fixtures/complex.thrift
@@ -1,6 +1,6 @@
 include 'simple'
 
-namespace js MyThing
+namespace js.ts MyThing
 
 typedef string Json
 typedef i32 MyInteger

--- a/src/resolve/namespace.ts
+++ b/src/resolve/namespace.ts
@@ -4,8 +4,7 @@ import { basename, extname } from 'path'
 
 // TODO: IDL has filename attached
 export function resolveNamespace(idl: JsonAST, filename: string) {
-  // TODO: the parser doesn't parse dot-separated namespaces
-  const scope = 'js'
+  const scope = 'js.ts'
 
   if (idl.namespace && idl.namespace[scope]) {
     const namespace = idl.namespace[scope].serviceName


### PR DESCRIPTION
This uses a custom namespace `js.ts` in the IDLs to namespace our generated code.