### PR TITLE
Add `size` getter to StructNode/ExceptionNode & remove hasFields (closes #42)

### DIFF
--- a/src/nodes/ExceptionNode.ts
+++ b/src/nodes/ExceptionNode.ts
@@ -33,7 +33,6 @@ export default class ExceptionNode extends StructNode {
     const superCall = createCall(createSuper(), undefined, [name])
 
     const fields = this.fields.map((field) => field.toAST())
-    const hasFields = (this.fields.length > 0)
 
     // Build the constructor body
     const ctor = createConstructor(this)
@@ -52,7 +51,7 @@ export default class ExceptionNode extends StructNode {
     ])
     heritage.push(extendsClause)
     // TODO: This is a pretty hacky solution
-    if (hasFields) {
+    if (this.size) {
       const implementsClause = createHeritageClause(SyntaxKind.ImplementsKeyword, [
         createExpressionWithTypeArguments(undefined, createIdentifier(this.implements)),
       ])

--- a/src/nodes/StructNode.ts
+++ b/src/nodes/StructNode.ts
@@ -25,10 +25,12 @@ export default class StructNode {
     this.fields = args.fields
   }
 
+  get size(): number {
+    return this.fields.length
+  }
+
   public toAST(): ExpressionStatement {
     const fields = this.fields.map((field) => field.toAST())
-
-    const hasFields = (this.fields.length > 0)
 
     // Build the constructor body
     const ctor = createConstructor(this)
@@ -41,7 +43,7 @@ export default class StructNode {
 
     const heritage = []
     // TODO: This is a pretty hacky solution
-    if (hasFields) {
+    if (this.size) {
       const implementsClause = createHeritageClause(SyntaxKind.ImplementsKeyword, [
         createExpressionWithTypeArguments(undefined, createIdentifier(this.implements)),
       ])


### PR DESCRIPTION
I'm not sure if getters need to be defined as `public` - It seems to be working like this.

I also added some typings to the `create` file to make refactoring easier.