### PR TITLE
In the struct read methods verify types before reading into fields

### DIFF
--- a/src/app/render/struct/read.ts
+++ b/src/app/render/struct/read.ts
@@ -162,14 +162,26 @@ export function createInputParameter(): ts.ParameterDeclaration {
  * @param field
  */
 export function createCaseForField(field: FieldDefinition, identifiers: IIdentifierMap): ts.CaseClause {
-  return ts.createCaseClause(
-    ts.createLiteral(field.fieldID.value),
-    [
-      ...readValueForFieldType(
+  const checkType: ts.IfStatement = ts.createIf(
+    createEquals(
+      COMMON_IDENTIFIERS['ftype'],
+      thriftPropertyAccessForFieldType(field.fieldType, identifiers)
+    ),
+    ts.createBlock(
+      readValueForFieldType(
         field.fieldType,
         ts.createIdentifier(`this.${field.name.value}`),
         identifiers
       ),
+      true
+    ),
+    createSkipBlock()
+  )
+
+  return ts.createCaseClause(
+    ts.createLiteral(field.fieldID.value),
+    [
+      checkType,
       ts.createBreak()
     ]
   )

--- a/src/app/render/union.ts
+++ b/src/app/render/union.ts
@@ -233,15 +233,26 @@ function createReadMethod(struct: UnionDefinition, identifiers: IIdentifierMap):
  * @param field
  */
 export function createCaseForField(field: FieldDefinition, identifiers: IIdentifierMap): ts.CaseClause {
+  const checkType: ts.IfStatement = ts.createIf(
+    createEquals(
+      COMMON_IDENTIFIERS['ftype'],
+      thriftPropertyAccessForFieldType(field.fieldType, identifiers)
+    ),
+    ts.createBlock([
+      incrementFieldsSet(),
+        ...readValueForFieldType(
+          field.fieldType,
+          ts.createIdentifier(`this.${field.name.value}`),
+          identifiers
+        ),
+    ],true),
+    createSkipBlock()
+  )
+
   return ts.createCaseClause(
     ts.createLiteral(field.fieldID.value),
     [
-      incrementFieldsSet(),
-      ...readValueForFieldType(
-        field.fieldType,
-        ts.createIdentifier(`this.${field.name.value}`),
-        identifiers
-      ),
+      checkType,
       ts.createBreak()
     ]
   )

--- a/src/tests/fixtures/basic_exception.solution.ts
+++ b/src/tests/fixtures/basic_exception.solution.ts
@@ -39,7 +39,12 @@ export class MyException {
             }
             switch (fid) {
                 case 1:
-                    this.message = input.readString();
+                    if (ftype === Thrift.Type.STRING) {
+                        this.message = input.readString();
+                    }
+                    else {
+                        input.skip(ftype);
+                    }
                     break;
                 default: {
                     input.skip(ftype);

--- a/src/tests/fixtures/basic_service.solution.ts
+++ b/src/tests/fixtures/basic_service.solution.ts
@@ -68,7 +68,12 @@ export class MyServicePingResult {
             }
             switch (fid) {
                 case 0:
-                    input.skip(ftype);
+                    if (ftype === Thrift.Type.VOID) {
+                        input.skip(ftype);
+                    }
+                    else {
+                        input.skip(ftype);
+                    }
                     break;
                 default: {
                     input.skip(ftype);

--- a/src/tests/fixtures/basic_union.solution.ts
+++ b/src/tests/fixtures/basic_union.solution.ts
@@ -56,12 +56,22 @@ export class MyUnion {
             }
             switch (fid) {
                 case 1:
-                    fieldsSet++;
-                    this.field1 = input.readString();
+                    if (ftype === Thrift.Type.STRING) {
+                        fieldsSet++;
+                        this.field1 = input.readString();
+                    }
+                    else {
+                        input.skip(ftype);
+                    }
                     break;
                 case 2:
-                    fieldsSet++;
-                    this.field2 = input.readString();
+                    if (ftype === Thrift.Type.STRING) {
+                        fieldsSet++;
+                        this.field2 = input.readString();
+                    }
+                    else {
+                        input.skip(ftype);
+                    }
                     break;
                 default: {
                     input.skip(ftype);

--- a/src/tests/fixtures/container_id_struct.solution.ts
+++ b/src/tests/fixtures/container_id_struct.solution.ts
@@ -39,7 +39,12 @@ export class OtherStruct {
             }
             switch (fid) {
                 case 1:
-                    this.name = input.readString();
+                    if (ftype === Thrift.Type.STRING) {
+                        this.name = input.readString();
+                    }
+                    else {
+                        input.skip(ftype);
+                    }
                     break;
                 default: {
                     input.skip(ftype);
@@ -96,18 +101,23 @@ export class MyStruct {
             }
             switch (fid) {
                 case 1:
-                    this.field1 = new Set<OtherStruct>();
-                    const metadata_1: {
-                        etype: Thrift.Type;
-                        size: number;
-                    } = input.readSetBegin();
-                    const size_1: number = metadata_1.size;
-                    for (let i_1: number = 0; i_1 < size_1; i_1++) {
-                        const value_2: OtherStruct = new OtherStruct();
-                        value_2.read(input);
-                        this.field1.add(value_2);
+                    if (ftype === Thrift.Type.SET) {
+                        this.field1 = new Set<OtherStruct>();
+                        const metadata_1: {
+                            etype: Thrift.Type;
+                            size: number;
+                        } = input.readSetBegin();
+                        const size_1: number = metadata_1.size;
+                        for (let i_1: number = 0; i_1 < size_1; i_1++) {
+                            const value_2: OtherStruct = new OtherStruct();
+                            value_2.read(input);
+                            this.field1.add(value_2);
+                        }
+                        input.readSetEnd();
                     }
-                    input.readSetEnd();
+                    else {
+                        input.skip(ftype);
+                    }
                     break;
                 default: {
                     input.skip(ftype);

--- a/src/tests/fixtures/list_struct.solution.ts
+++ b/src/tests/fixtures/list_struct.solution.ts
@@ -43,17 +43,22 @@ export class MyStruct {
             }
             switch (fid) {
                 case 1:
-                    this.field1 = new Array<string>();
-                    const metadata_1: {
-                        etype: Thrift.Type;
-                        size: number;
-                    } = input.readListBegin();
-                    const size_1: number = metadata_1.size;
-                    for (let i_1: number = 0; i_1 < size_1; i_1++) {
-                        const value_2: string = input.readString();
-                        this.field1.push(value_2);
+                    if (ftype === Thrift.Type.LIST) {
+                        this.field1 = new Array<string>();
+                        const metadata_1: {
+                            etype: Thrift.Type;
+                            size: number;
+                        } = input.readListBegin();
+                        const size_1: number = metadata_1.size;
+                        for (let i_1: number = 0; i_1 < size_1; i_1++) {
+                            const value_2: string = input.readString();
+                            this.field1.push(value_2);
+                        }
+                        input.readListEnd();
                     }
-                    input.readListEnd();
+                    else {
+                        input.skip(ftype);
+                    }
                     break;
                 default: {
                     input.skip(ftype);

--- a/src/tests/fixtures/map_struct.solution.ts
+++ b/src/tests/fixtures/map_struct.solution.ts
@@ -44,19 +44,24 @@ export class MyStruct {
             }
             switch (fid) {
                 case 1:
-                    this.field1 = new Map<string, string>();
-                    const metadata_1: {
-                        ktype: Thrift.Type;
-                        vtype: Thrift.Type;
-                        size: number;
-                    } = input.readMapBegin();
-                    const size_1: number = metadata_1.size;
-                    for (let i_1: number = 0; i_1 < size_1; i_1++) {
-                        const key_2: string = input.readString();
-                        const value_2: string = input.readString();
-                        this.field1.set(key_2, value_2);
+                    if (ftype === Thrift.Type.MAP) {
+                        this.field1 = new Map<string, string>();
+                        const metadata_1: {
+                            ktype: Thrift.Type;
+                            vtype: Thrift.Type;
+                            size: number;
+                        } = input.readMapBegin();
+                        const size_1: number = metadata_1.size;
+                        for (let i_1: number = 0; i_1 < size_1; i_1++) {
+                            const key_2: string = input.readString();
+                            const value_2: string = input.readString();
+                            this.field1.set(key_2, value_2);
+                        }
+                        input.readMapEnd();
                     }
-                    input.readMapEnd();
+                    else {
+                        input.skip(ftype);
+                    }
                     break;
                 default: {
                     input.skip(ftype);

--- a/src/tests/fixtures/multi_field_struct.solution.ts
+++ b/src/tests/fixtures/multi_field_struct.solution.ts
@@ -62,13 +62,28 @@ export class MyStruct {
             }
             switch (fid) {
                 case 1:
-                    this.id = input.readI32();
+                    if (ftype === Thrift.Type.I32) {
+                        this.id = input.readI32();
+                    }
+                    else {
+                        input.skip(ftype);
+                    }
                     break;
                 case 2:
-                    this.word = input.readString();
+                    if (ftype === Thrift.Type.STRING) {
+                        this.word = input.readString();
+                    }
+                    else {
+                        input.skip(ftype);
+                    }
                     break;
                 case 3:
-                    this.field1 = input.readDouble();
+                    if (ftype === Thrift.Type.DOUBLE) {
+                        this.field1 = input.readDouble();
+                    }
+                    else {
+                        input.skip(ftype);
+                    }
                     break;
                 default: {
                     input.skip(ftype);

--- a/src/tests/fixtures/nested_list_struct.solution.ts
+++ b/src/tests/fixtures/nested_list_struct.solution.ts
@@ -47,27 +47,32 @@ export class MyStruct {
             }
             switch (fid) {
                 case 1:
-                    this.field1 = new Array<Array<string>>();
-                    const metadata_1: {
-                        etype: Thrift.Type;
-                        size: number;
-                    } = input.readListBegin();
-                    const size_1: number = metadata_1.size;
-                    for (let i_1: number = 0; i_1 < size_1; i_1++) {
-                        const value_3: Array<string> = new Array<string>();
-                        const metadata_2: {
+                    if (ftype === Thrift.Type.LIST) {
+                        this.field1 = new Array<Array<string>>();
+                        const metadata_1: {
                             etype: Thrift.Type;
                             size: number;
                         } = input.readListBegin();
-                        const size_2: number = metadata_2.size;
-                        for (let i_2: number = 0; i_2 < size_2; i_2++) {
-                            const value_4: string = input.readString();
-                            value_3.push(value_4);
+                        const size_1: number = metadata_1.size;
+                        for (let i_1: number = 0; i_1 < size_1; i_1++) {
+                            const value_3: Array<string> = new Array<string>();
+                            const metadata_2: {
+                                etype: Thrift.Type;
+                                size: number;
+                            } = input.readListBegin();
+                            const size_2: number = metadata_2.size;
+                            for (let i_2: number = 0; i_2 < size_2; i_2++) {
+                                const value_4: string = input.readString();
+                                value_3.push(value_4);
+                            }
+                            input.readListEnd();
+                            this.field1.push(value_3);
                         }
                         input.readListEnd();
-                        this.field1.push(value_3);
                     }
-                    input.readListEnd();
+                    else {
+                        input.skip(ftype);
+                    }
                     break;
                 default: {
                     input.skip(ftype);

--- a/src/tests/fixtures/nested_map_struct.solution.ts
+++ b/src/tests/fixtures/nested_map_struct.solution.ts
@@ -49,31 +49,36 @@ export class MyStruct {
             }
             switch (fid) {
                 case 1:
-                    this.field1 = new Map<string, Map<string, number>>();
-                    const metadata_1: {
-                        ktype: Thrift.Type;
-                        vtype: Thrift.Type;
-                        size: number;
-                    } = input.readMapBegin();
-                    const size_1: number = metadata_1.size;
-                    for (let i_1: number = 0; i_1 < size_1; i_1++) {
-                        const key_3: string = input.readString();
-                        const value_3: Map<string, number> = new Map<string, number>();
-                        const metadata_2: {
+                    if (ftype === Thrift.Type.MAP) {
+                        this.field1 = new Map<string, Map<string, number>>();
+                        const metadata_1: {
                             ktype: Thrift.Type;
                             vtype: Thrift.Type;
                             size: number;
                         } = input.readMapBegin();
-                        const size_2: number = metadata_2.size;
-                        for (let i_2: number = 0; i_2 < size_2; i_2++) {
-                            const key_4: string = input.readString();
-                            const value_4: number = input.readI32();
-                            value_3.set(key_4, value_4);
+                        const size_1: number = metadata_1.size;
+                        for (let i_1: number = 0; i_1 < size_1; i_1++) {
+                            const key_3: string = input.readString();
+                            const value_3: Map<string, number> = new Map<string, number>();
+                            const metadata_2: {
+                                ktype: Thrift.Type;
+                                vtype: Thrift.Type;
+                                size: number;
+                            } = input.readMapBegin();
+                            const size_2: number = metadata_2.size;
+                            for (let i_2: number = 0; i_2 < size_2; i_2++) {
+                                const key_4: string = input.readString();
+                                const value_4: number = input.readI32();
+                                value_3.set(key_4, value_4);
+                            }
+                            input.readMapEnd();
+                            this.field1.set(key_3, value_3);
                         }
                         input.readMapEnd();
-                        this.field1.set(key_3, value_3);
                     }
-                    input.readMapEnd();
+                    else {
+                        input.skip(ftype);
+                    }
                     break;
                 default: {
                     input.skip(ftype);

--- a/src/tests/fixtures/nested_set_struct.solution.ts
+++ b/src/tests/fixtures/nested_set_struct.solution.ts
@@ -47,27 +47,32 @@ export class MyStruct {
             }
             switch (fid) {
                 case 1:
-                    this.field1 = new Set<Set<string>>();
-                    const metadata_1: {
-                        etype: Thrift.Type;
-                        size: number;
-                    } = input.readSetBegin();
-                    const size_1: number = metadata_1.size;
-                    for (let i_1: number = 0; i_1 < size_1; i_1++) {
-                        const value_3: Set<string> = new Set<string>();
-                        const metadata_2: {
+                    if (ftype === Thrift.Type.SET) {
+                        this.field1 = new Set<Set<string>>();
+                        const metadata_1: {
                             etype: Thrift.Type;
                             size: number;
                         } = input.readSetBegin();
-                        const size_2: number = metadata_2.size;
-                        for (let i_2: number = 0; i_2 < size_2; i_2++) {
-                            const value_4: string = input.readString();
-                            value_3.add(value_4);
+                        const size_1: number = metadata_1.size;
+                        for (let i_1: number = 0; i_1 < size_1; i_1++) {
+                            const value_3: Set<string> = new Set<string>();
+                            const metadata_2: {
+                                etype: Thrift.Type;
+                                size: number;
+                            } = input.readSetBegin();
+                            const size_2: number = metadata_2.size;
+                            for (let i_2: number = 0; i_2 < size_2; i_2++) {
+                                const value_4: string = input.readString();
+                                value_3.add(value_4);
+                            }
+                            input.readSetEnd();
+                            this.field1.add(value_3);
                         }
                         input.readSetEnd();
-                        this.field1.add(value_3);
                     }
-                    input.readSetEnd();
+                    else {
+                        input.skip(ftype);
+                    }
                     break;
                 default: {
                     input.skip(ftype);

--- a/src/tests/fixtures/return_id_struct.solution.ts
+++ b/src/tests/fixtures/return_id_struct.solution.ts
@@ -39,7 +39,12 @@ export class OtherStruct {
             }
             switch (fid) {
                 case 1:
-                    this.name = input.readString();
+                    if (ftype === Thrift.Type.STRING) {
+                        this.name = input.readString();
+                    }
+                    else {
+                        input.skip(ftype);
+                    }
                     break;
                 default: {
                     input.skip(ftype);
@@ -92,8 +97,13 @@ export class MyStruct {
             }
             switch (fid) {
                 case 1:
-                    this.field1 = new OtherStruct();
-                    this.field1.read(input);
+                    if (ftype === Thrift.Type.STRUCT) {
+                        this.field1 = new OtherStruct();
+                        this.field1.read(input);
+                    }
+                    else {
+                        input.skip(ftype);
+                    }
                     break;
                 default: {
                     input.skip(ftype);

--- a/src/tests/fixtures/return_service.solution.ts
+++ b/src/tests/fixtures/return_service.solution.ts
@@ -36,7 +36,12 @@ export class MyException {
             }
             switch (fid) {
                 case 1:
-                    this.message = input.readString();
+                    if (ftype === Thrift.Type.STRING) {
+                        this.message = input.readString();
+                    }
+                    else {
+                        input.skip(ftype);
+                    }
                     break;
                 default: {
                     input.skip(ftype);
@@ -86,7 +91,12 @@ export class MyServicePingArgs {
             }
             switch (fid) {
                 case 1:
-                    this.status = input.readI32();
+                    if (ftype === Thrift.Type.I32) {
+                        this.status = input.readI32();
+                    }
+                    else {
+                        input.skip(ftype);
+                    }
                     break;
                 default: {
                     input.skip(ftype);
@@ -146,11 +156,21 @@ export class MyServicePingResult {
             }
             switch (fid) {
                 case 0:
-                    this.success = input.readString();
+                    if (ftype === Thrift.Type.STRING) {
+                        this.success = input.readString();
+                    }
+                    else {
+                        input.skip(ftype);
+                    }
                     break;
                 case 1:
-                    this.exp = new MyException();
-                    this.exp.read(input);
+                    if (ftype === Thrift.Type.STRUCT) {
+                        this.exp = new MyException();
+                        this.exp.read(input);
+                    }
+                    else {
+                        input.skip(ftype);
+                    }
                     break;
                 default: {
                     input.skip(ftype);

--- a/src/tests/fixtures/set_struct.solution.ts
+++ b/src/tests/fixtures/set_struct.solution.ts
@@ -43,17 +43,22 @@ export class MyStruct {
             }
             switch (fid) {
                 case 1:
-                    this.field1 = new Set<string>();
-                    const metadata_1: {
-                        etype: Thrift.Type;
-                        size: number;
-                    } = input.readSetBegin();
-                    const size_1: number = metadata_1.size;
-                    for (let i_1: number = 0; i_1 < size_1; i_1++) {
-                        const value_2: string = input.readString();
-                        this.field1.add(value_2);
+                    if (ftype === Thrift.Type.SET) {
+                        this.field1 = new Set<string>();
+                        const metadata_1: {
+                            etype: Thrift.Type;
+                            size: number;
+                        } = input.readSetBegin();
+                        const size_1: number = metadata_1.size;
+                        for (let i_1: number = 0; i_1 < size_1; i_1++) {
+                            const value_2: string = input.readString();
+                            this.field1.add(value_2);
+                        }
+                        input.readSetEnd();
                     }
-                    input.readSetEnd();
+                    else {
+                        input.skip(ftype);
+                    }
                     break;
                 default: {
                     input.skip(ftype);

--- a/src/tests/fixtures/throw_service.solution.ts
+++ b/src/tests/fixtures/throw_service.solution.ts
@@ -36,7 +36,12 @@ export class MyException {
             }
             switch (fid) {
                 case 1:
-                    this.message = input.readString();
+                    if (ftype === Thrift.Type.STRING) {
+                        this.message = input.readString();
+                    }
+                    else {
+                        input.skip(ftype);
+                    }
                     break;
                 default: {
                     input.skip(ftype);
@@ -128,11 +133,21 @@ export class MyServicePingResult {
             }
             switch (fid) {
                 case 0:
-                    input.skip(ftype);
+                    if (ftype === Thrift.Type.VOID) {
+                        input.skip(ftype);
+                    }
+                    else {
+                        input.skip(ftype);
+                    }
                     break;
                 case 1:
-                    this.exp = new MyException();
-                    this.exp.read(input);
+                    if (ftype === Thrift.Type.STRUCT) {
+                        this.exp = new MyException();
+                        this.exp.read(input);
+                    }
+                    else {
+                        input.skip(ftype);
+                    }
                     break;
                 default: {
                     input.skip(ftype);


### PR DESCRIPTION
Previously we had been verifying types in the struct read method before performing reads into fields. I dropped this when I was trying to get to equivalence with Scrooge, but am putting it back in as it is compatible with the Scrooge code.