### PR TITLE
Add support for assigning 0 or 1 to bool field

### DIFF
--- a/src/main/validator/index.ts
+++ b/src/main/validator/index.ts
@@ -11,6 +11,7 @@ import {
   FunctionType,
   PropertyAssignment,
   Identifier,
+  createBooleanLiteral,
 } from '@creditkarma/thrift-parser'
 
 import {
@@ -347,6 +348,8 @@ export function validateFile(resolvedFile: IResolvedFile): IResolvedFile {
       case SyntaxType.BoolKeyword:
         if (value.type === SyntaxType.BooleanLiteral) {
           return value
+        } else if (value.type === SyntaxType.IntConstant && (value.value === 0 || value.value === 1)) {
+          return createBooleanLiteral(value.value === 1, value.loc)
         } else {
           throw typeMismatch(expectedType, value, value.loc)
         }

--- a/src/tests/unit/validator.spec.ts
+++ b/src/tests/unit/validator.spec.ts
@@ -1600,4 +1600,50 @@ describe('Thrift TypeScript Validator', () => {
 
     assert.deepEqual(validatedFile, expected)
   })
+
+  it('should not return an error if assigning an int with value 0 or 1 to a bool field', () => {
+    const content: string = `
+      struct TestStruct {
+        1: bool testFalse = 0
+        2: bool testTrue = 1
+      }
+    `;
+    const parsedFile: IParsedFile = parseSource(content)
+    const resolvedAST: IResolvedFile = resolveFile(parsedFile)
+    const validatedAST: IResolvedFile = validateFile(resolvedAST)
+    const expected: Array<IThriftError> = []
+
+    assert.deepEqual(validatedAST.errors, expected)
+  })
+
+  it('should return an error if assigning an int with value not 0 or 1 to a bool field', () => {
+    const content: string = `
+      struct TestStruct {
+        1: bool test = 2
+      }
+    `;
+    const parsedFile: IParsedFile = parseSource(content)
+    const resolvedAST: IResolvedFile = resolveFile(parsedFile)
+    const validatedAST: IResolvedFile = validateFile(resolvedAST)
+    const expected: Array<IThriftError> = [
+      {
+        type: ErrorType.ValidationError,
+        message: 'Expected type boolean but found type number',
+        loc: {
+          start: {
+            line: 3,
+            column: 24,
+            index: 50
+          },
+          end: {
+            line: 3,
+            column: 25,
+            index: 51
+          }
+        }
+      }
+    ]
+
+    assert.deepEqual(validatedAST.errors, expected)
+  })
 })


### PR DESCRIPTION
If an int literal is found when assigning to a bool field and it has a value of 0 or 1, convert it to a bool literal of false or true.