### PR TITLE
Support i64 values

### DIFF
--- a/src/main/render/enum.ts
+++ b/src/main/render/enum.ts
@@ -32,7 +32,7 @@ export function renderEnum(node: EnumDefinition): ts.Statement {
         field.name.value,
         (
           (field.initializer !== null) ?
-            ts.createLiteral(field.initializer.value) :
+            ts.createLiteral(parseInt(field.initializer.value)) :
             undefined
         ),
       )

--- a/src/main/render/types.ts
+++ b/src/main/render/types.ts
@@ -104,7 +104,10 @@ export function typeNodeForFieldType(fieldType: FunctionType): ts.TypeNode {
       return createBooleanType()
 
     case SyntaxType.I64Keyword:
-      return ts.createTypeReferenceNode(COMMON_IDENTIFIERS.Int64, undefined)
+      return ts.createUnionTypeNode([
+        createNumberType(),
+        ts.createTypeReferenceNode(COMMON_IDENTIFIERS.Int64, undefined),
+      ])
 
     case SyntaxType.DoubleKeyword:
     case SyntaxType.I8Keyword:

--- a/src/main/render/values.ts
+++ b/src/main/render/values.ts
@@ -30,7 +30,7 @@ export function renderValue(fieldType: FunctionType, node: ConstValue): ts.Expre
           [ ts.createLiteral(node.value) ]
         )
       } else {
-        return ts.createLiteral(node.value)
+        return ts.createLiteral(parseInt(node.value))
       }
 
     case SyntaxType.BooleanLiteral:

--- a/src/main/validator/index.ts
+++ b/src/main/validator/index.ts
@@ -242,7 +242,7 @@ export function validateFile(resolvedFile: IResolvedFile): IResolvedFile {
     let previousValue: number = -1
     const values: Array<number | null> = enumDef.members.reduce((acc: Array<number | null>, next: EnumMember): Array<number | null> => {
       if (next.initializer !== null) {
-        return [ ...acc, next.initializer.value ]
+        return [ ...acc, parseInt(next.initializer.value) ]
       } else {
         return [ ...acc, null ]
       }
@@ -291,7 +291,7 @@ export function validateFile(resolvedFile: IResolvedFile): IResolvedFile {
        */
       case SyntaxType.IntConstant:
         const acceptedValues: Array<number> = valuesForEnum(enumDef)
-        if (acceptedValues.indexOf(constValue.value) > -1) {
+        if (acceptedValues.indexOf(parseInt(constValue.value)) > -1) {
           return constValue
         } else {
           throw new ValidationError(`The value ${constValue.value} is not assignable to type ${enumDef.name.value}`, constValue.loc)
@@ -348,8 +348,8 @@ export function validateFile(resolvedFile: IResolvedFile): IResolvedFile {
       case SyntaxType.BoolKeyword:
         if (value.type === SyntaxType.BooleanLiteral) {
           return value
-        } else if (value.type === SyntaxType.IntConstant && (value.value === 0 || value.value === 1)) {
-          return createBooleanLiteral(value.value === 1, value.loc)
+        } else if (value.type === SyntaxType.IntConstant && (value.value === '0' || value.value === '1')) {
+          return createBooleanLiteral(value.value === '1', value.loc)
         } else {
           throw typeMismatch(expectedType, value, value.loc)
         }

--- a/src/tests/fixtures/multi_field_struct.solution.ts
+++ b/src/tests/fixtures/multi_field_struct.solution.ts
@@ -1,12 +1,12 @@
 export interface IMyStructArgs {
     id: number;
-    bigID: thrift.Int64;
+    bigID: number | thrift.Int64;
     word: string;
     field1?: number;
 }
 export class MyStruct {
     public id: number = 45;
-    public bigID: thrift.Int64 = new thrift.Int64(23948234);
+    public bigID: number | thrift.Int64 = new thrift.Int64("23948234");
     public word: string;
     public field1: number;
     constructor(args?: IMyStructArgs) {
@@ -85,7 +85,7 @@ export class MyStruct {
                     break;
                 case 2:
                     if (ftype === thrift.Thrift.Type.I64) {
-                        const value_2: thrift.Int64 = input.readI64();
+                        const value_2: number | thrift.Int64 = input.readI64();
                         this.bigID = value_2;
                     }
                     else {


### PR DESCRIPTION
Following https://github.com/creditkarma/thrift-parser/pull/37, move `parseInt` for `IntConstant.value` to renderer and render `Int64` with a string value.

Also change type definitions to `number | Int64` for better service interfaces. The underlying `thrift` library's `writeI64` uses this as its argument type.