### PR TITLE
Use sync file write so that errors can be handled in normal control flow

### DIFF
--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -72,11 +72,11 @@ function collectAllFiles(files: Array<IRenderedFile>): Array<IRenderedFile> {
 export function saveFiles(rootDir: string, outDir: string, files: Array<IRenderedFile>): void {
   collectAllFiles(files).forEach((next: IRenderedFile) => {
     mkdir(path.dirname(next.outPath))
-    fs.writeFile(next.outPath, print(next.statements, true), (err: Error) => {
-      if (err != null) {
-        throw new Error(`Unable to save generated files to: ${next.outPath}`)
-      }
-    })
+    try {
+      fs.writeFileSync(next.outPath, print(next.statements, true))
+    } catch (err) {
+      throw new Error(`Unable to save generated files to: ${next.outPath}`)
+    }
   })
 }
 


### PR DESCRIPTION
I wanted to be able to do something like this:

```
try { 
   generate(...)
} catch (e) {
   // handle errors
}
```

Which typically works, since most of the code is synchronous. The only bit that is async is the very last bit when the files are written:
```
fs.writeFile(next.outPath, print(next.statements, true), (err: Error) => {
     if (err != null) {
        throw new Error(`Unable to save generated files to: ${next.outPath}`)
     }
})
```

I couldn't find a way to catch / handle this error, so I made the final write sync so that errors can be handled by calling programs.