### PR TITLE
Fix generation of service function that throws and does not return

### DIFF
--- a/src/main/render/apache/service/client.ts
+++ b/src/main/render/apache/service/client.ts
@@ -531,7 +531,7 @@ function createRecvMethodForDefinition(service: ServiceDefinition, def: Function
 }
 
 function createNewResultInstance(def: FunctionDefinition): Array<ts.Statement> {
-    if (def.returnType.type === SyntaxType.VoidKeyword) {
+    if (def.returnType.type === SyntaxType.VoidKeyword && !def.throws.length) {
         return []
     } else {
         return [

--- a/src/tests/unit/fixtures/apache/throw_service.solution.ts
+++ b/src/tests/unit/fixtures/apache/throw_service.solution.ts
@@ -194,6 +194,7 @@ export namespace MyService {
                 input.readMessageEnd();
                 return callback(x);
             }
+            const result: PingResult = PingResult.read(input);
             input.readMessageEnd();
             if (result.exp != null) {
                 return callback(result.exp);


### PR DESCRIPTION
Create new result instance when generating `recv` method for definitions if the return type of the service method is `void` and it `throws an exception` too.