### PR TITLE
Import Int64 type

### DIFF
--- a/src/main/render/apache/includes.ts
+++ b/src/main/render/apache/includes.ts
@@ -7,6 +7,8 @@ import {
     IResolvedIncludeMap,
 } from '../../types'
 
+import { COMMON_IDENTIFIERS } from '../shared/identifiers'
+
 /**
  * import { Thrift, TProtocol, TTransport, Int64 } from 'thrift';
  *
@@ -66,4 +68,19 @@ export function renderIncludes(
     }
 
     return imports
+}
+
+/**
+ * import Int64 = require('node-int64');
+ *
+ * Creates an import for Int64 type if it is being used by the file we're
+ * generating. We'll need to keep track of what each files uses.
+ */
+export function renderInt64Import(): ts.ImportEqualsDeclaration {
+    return ts.createImportEqualsDeclaration(
+        undefined,
+        undefined,
+        COMMON_IDENTIFIERS.Node_Int64,
+        ts.createExternalModuleReference(ts.createLiteral('node-int64')),
+    )
 }

--- a/src/main/render/apache/index.ts
+++ b/src/main/render/apache/index.ts
@@ -24,12 +24,13 @@ import {
     renderResultStruct,
 } from './service'
 
-import { fileUsesThrift } from '../shared/includes'
+import { fileUsesInt64, fileUsesThrift } from '../shared/includes'
 import { renderTypeDef as _renderTypeDef } from '../shared/typedef'
 import { renderConst as _renderConst } from './const'
 import { renderEnum as _renderEnum } from './enum'
 import {
     renderIncludes as _renderIncludes,
+    renderInt64Import,
     renderThriftImports,
 } from './includes'
 import { renderStruct as _renderStruct } from './struct'
@@ -46,14 +47,19 @@ export function renderIncludes(
     outPath: string,
     currentPath: string,
     resolvedFile: INamespaceFile): Array<ts.Statement> {
-    if (fileUsesThrift(resolvedFile)) {
-        return [
-            renderThriftImports(),
+        const includes: Array<ts.Statement> = [
             ..._renderIncludes(outPath, currentPath, resolvedFile.includes),
         ]
-    } else {
-        return _renderIncludes(outPath, currentPath, resolvedFile.includes)
-    }
+
+        if (fileUsesThrift(resolvedFile)) {
+            includes.unshift(renderThriftImports())
+        }
+
+        if (fileUsesInt64(resolvedFile)) {
+            includes.unshift(renderInt64Import())
+        }
+
+        return includes
 }
 
 export function renderConst(statement: ConstDefinition, identifiers: IIdentifierMap): Array<ts.Statement> {

--- a/src/main/render/apache/struct/create.ts
+++ b/src/main/render/apache/struct/create.ts
@@ -124,7 +124,7 @@ export function assignmentForField(field: FieldDefinition): ts.Statement {
                 createAssignmentStatement(
                     propertyAccessForIdentifier('this', field.name.value),
                     ts.createNew(
-                        COMMON_IDENTIFIERS.Int64,
+                        COMMON_IDENTIFIERS.Node_Int64,
                         undefined,
                         [
                             ts.createIdentifier(`args.${field.name.value}`),

--- a/src/main/render/apache/types.ts
+++ b/src/main/render/apache/types.ts
@@ -237,12 +237,12 @@ export function typeNodeForFieldType(fieldType: FunctionType, loose: boolean = f
                 return ts.createUnionTypeNode([
                     createNumberType(),
                     ts.createTypeReferenceNode(
-                        COMMON_IDENTIFIERS.Int64,
+                        COMMON_IDENTIFIERS.Node_Int64,
                         undefined,
                     ),
                 ])
             } else {
-                return ts.createTypeReferenceNode(COMMON_IDENTIFIERS.Int64, undefined)
+                return ts.createTypeReferenceNode(COMMON_IDENTIFIERS.Node_Int64, undefined)
             }
 
         case SyntaxType.BinaryKeyword:

--- a/src/main/render/apache/values.ts
+++ b/src/main/render/apache/values.ts
@@ -74,7 +74,7 @@ export function renderIntConstant(node: IntConstant, fieldType?: FunctionType): 
         case SyntaxType.IntegerLiteral:
             if (fieldType && fieldType.type === SyntaxType.I64Keyword) {
                 return ts.createNew(
-                    COMMON_IDENTIFIERS.Int64,
+                    COMMON_IDENTIFIERS.Node_Int64,
                     undefined,
                     [
                         ts.createLiteral(parseInt(node.value.value, 10)),
@@ -88,7 +88,7 @@ export function renderIntConstant(node: IntConstant, fieldType?: FunctionType): 
             // The Int64 constructor accepts hex literals as strings
             if (fieldType && fieldType.type === SyntaxType.I64Keyword) {
                 return ts.createNew(
-                    COMMON_IDENTIFIERS.Int64,
+                    COMMON_IDENTIFIERS.Node_Int64,
                     undefined,
                     [
                         ts.createLiteral(node.value.value),

--- a/src/main/render/shared/identifiers.ts
+++ b/src/main/render/shared/identifiers.ts
@@ -53,4 +53,5 @@ export const COMMON_IDENTIFIERS = {
     Int64: ts.createIdentifier('thrift.Int64'),
     IHandler: ts.createIdentifier('IHandler'),
     ILocalHandler: ts.createIdentifier('ILocalHandler'),
+    Node_Int64: ts.createIdentifier('Int64'),
 }

--- a/src/main/render/shared/includes.ts
+++ b/src/main/render/shared/includes.ts
@@ -1,5 +1,7 @@
 import {
     ConstDefinition,
+    FieldDefinition,
+    FunctionDefinition,
     SyntaxType,
     ThriftStatement,
     TypedefDefinition,
@@ -43,9 +45,51 @@ function statementUsesThrift(statement: ThriftStatement): boolean {
     }
 }
 
+function statementUsesInt64(statement: ThriftStatement): boolean {
+    switch (statement.type) {
+        case SyntaxType.ServiceDefinition:
+            return statement.functions.some((func: FunctionDefinition) => {
+                return func.returnType.type === SyntaxType.I64Keyword
+            })
+
+        case SyntaxType.StructDefinition:
+        case SyntaxType.UnionDefinition:
+        case SyntaxType.ExceptionDefinition:
+            return statement.fields.some((field: FieldDefinition) => {
+                return field.fieldType.type === SyntaxType.I64Keyword
+            })
+
+        case SyntaxType.NamespaceDefinition:
+        case SyntaxType.IncludeDefinition:
+        case SyntaxType.CppIncludeDefinition:
+        case SyntaxType.EnumDefinition:
+            return false
+
+        case SyntaxType.ConstDefinition:
+            return constUsesThrift(statement)
+
+        case SyntaxType.TypedefDefinition:
+            return typedefUsesThrift(statement)
+
+        default:
+            const msg: never = statement
+            throw new Error(`Non-exhaustive match for ${msg}`)
+    }
+}
+
 export function fileUsesThrift(resolvedFile: INamespaceFile): boolean {
     for (const statement of resolvedFile.body) {
         if (statementUsesThrift(statement)) {
+            return true
+        }
+    }
+
+    return false
+}
+
+export function fileUsesInt64(resolvedFile: INamespaceFile): boolean {
+    for (const statement of resolvedFile.body) {
+        if (statementUsesInt64(statement)) {
             return true
         }
     }

--- a/src/tests/unit/fixtures/apache/basic_const.solution.ts
+++ b/src/tests/unit/fixtures/apache/basic_const.solution.ts
@@ -1,5 +1,5 @@
 export const FALSE_CONST: boolean = false;
-export const INT_64: thrift.Int64 = new thrift.Int64(64);
+export const INT_64: Int64 = new Int64(64);
 export const SET_CONST: Set<string> = new Set(["hello", "world", "foo", "bar"]);
 export const MAP_CONST: Map<string, string> = new Map([["hello", "world"], ["foo", "bar"]]);
 export const LIST_CONST: Array<string> = ["hello", "world", "foo", "bar"];

--- a/src/tests/unit/fixtures/apache/i64_service.solution.ts
+++ b/src/tests/unit/fixtures/apache/i64_service.solution.ts
@@ -1,15 +1,15 @@
 export namespace MyService {
     export interface IAddArgsArgs {
-        num1: number | thrift.Int64;
-        num2: number | thrift.Int64;
+        num1: number | Int64;
+        num2: number | Int64;
     }
     export class AddArgs {
-        public num1: thrift.Int64;
-        public num2: thrift.Int64;
+        public num1: Int64;
+        public num2: Int64;
         constructor(args: IAddArgsArgs) {
             if (args != null && args.num1 != null) {
                 if (typeof args.num1 === "number") {
-                    this.num1 = new thrift.Int64(args.num1);
+                    this.num1 = new Int64(args.num1);
                 }
                 else {
                     this.num1 = args.num1;
@@ -20,7 +20,7 @@ export namespace MyService {
             }
             if (args != null && args.num2 != null) {
                 if (typeof args.num2 === "number") {
-                    this.num2 = new thrift.Int64(args.num2);
+                    this.num2 = new Int64(args.num2);
                 }
                 else {
                     this.num2 = args.num2;
@@ -59,7 +59,7 @@ export namespace MyService {
                 switch (fieldId) {
                     case 1:
                         if (fieldType === thrift.Thrift.Type.I64) {
-                            const value_1: thrift.Int64 = input.readI64();
+                            const value_1: Int64 = input.readI64();
                             _args.num1 = value_1;
                         }
                         else {
@@ -68,7 +68,7 @@ export namespace MyService {
                         break;
                     case 2:
                         if (fieldType === thrift.Thrift.Type.I64) {
-                            const value_2: thrift.Int64 = input.readI64();
+                            const value_2: Int64 = input.readI64();
                             _args.num2 = value_2;
                         }
                         else {
@@ -91,14 +91,14 @@ export namespace MyService {
         }
     }
     export interface IAddResultArgs {
-        success?: number | thrift.Int64;
+        success?: number | Int64;
     }
     export class AddResult {
-        public success?: thrift.Int64;
+        public success?: Int64;
         constructor(args?: IAddResultArgs) {
             if (args != null && args.success != null) {
                 if (typeof args.success === "number") {
-                    this.success = new thrift.Int64(args.success);
+                    this.success = new Int64(args.success);
                 }
                 else {
                     this.success = args.success;
@@ -129,7 +129,7 @@ export namespace MyService {
                 switch (fieldId) {
                     case 0:
                         if (fieldType === thrift.Thrift.Type.I64) {
-                            const value_3: thrift.Int64 = input.readI64();
+                            const value_3: Int64 = input.readI64();
                             _args.success = value_3;
                         }
                         else {
@@ -162,9 +162,9 @@ export namespace MyService {
         public incrementSeqId(): number {
             return this._seqid += 1;
         }
-        public add(num1: thrift.Int64, num2: thrift.Int64): Promise<thrift.Int64> {
+        public add(num1: Int64, num2: Int64): Promise<Int64> {
             const requestId: number = this.incrementSeqId();
-            return new Promise<thrift.Int64>((resolve, reject): void => {
+            return new Promise<Int64>((resolve, reject): void => {
                 this._reqs[requestId] = (error, result) => {
                     delete this._reqs[requestId];
                     if (error != null) {
@@ -177,7 +177,7 @@ export namespace MyService {
                 this.send_add(num1, num2, requestId);
             });
         }
-        public send_add(num1: thrift.Int64, num2: thrift.Int64, requestId: number): void {
+        public send_add(num1: Int64, num2: Int64, requestId: number): void {
             const output: thrift.TProtocol = new this.protocol(this.output);
             output.writeMessageBegin("add", thrift.Thrift.MessageType.CALL, requestId);
             const args: AddArgs = new AddArgs({ num1, num2 });
@@ -206,7 +206,7 @@ export namespace MyService {
         }
     }
     export interface IHandler {
-        add(num1: thrift.Int64, num2: thrift.Int64): thrift.Int64 | Promise<thrift.Int64>;
+        add(num1: Int64, num2: Int64): Int64 | Promise<Int64>;
     }
     export class Processor {
         public _handler: IHandler;
@@ -237,7 +237,7 @@ export namespace MyService {
             }
         }
         public process_add(requestId: number, input: thrift.TProtocol, output: thrift.TProtocol): void {
-            new Promise<thrift.Int64>((resolve, reject): void => {
+            new Promise<Int64>((resolve, reject): void => {
                 try {
                     const args: AddArgs = AddArgs.read(input);
                     input.readMessageEnd();
@@ -246,7 +246,7 @@ export namespace MyService {
                 catch (err) {
                     reject(err);
                 }
-            }).then((data: thrift.Int64): void => {
+            }).then((data: Int64): void => {
                 const result: AddResult = new AddResult({ success: data });
                 output.writeMessageBegin("add", thrift.Thrift.MessageType.REPLY, requestId);
                 result.write(output);

--- a/src/tests/unit/fixtures/apache/multi_field_struct.solution.ts
+++ b/src/tests/unit/fixtures/apache/multi_field_struct.solution.ts
@@ -1,13 +1,13 @@
 export interface IMyStructArgs {
     id: number;
-    bigID: number | thrift.Int64;
+    bigID: number | Int64;
     word: string;
     field1?: number;
     blob?: Buffer;
 }
 export class MyStruct {
     public id: number = 45;
-    public bigID: thrift.Int64 = new thrift.Int64(23948234);
+    public bigID: Int64 = new Int64(23948234);
     public word: string;
     public field1?: number;
     public blob?: Buffer = Buffer.from("binary");
@@ -20,7 +20,7 @@ export class MyStruct {
         }
         if (args != null && args.bigID != null) {
             if (typeof args.bigID === "number") {
-                this.bigID = new thrift.Int64(args.bigID);
+                this.bigID = new Int64(args.bigID);
             }
             else {
                 this.bigID = args.bigID;
@@ -95,7 +95,7 @@ export class MyStruct {
                     break;
                 case 2:
                     if (fieldType === thrift.Thrift.Type.I64) {
-                        const value_2: thrift.Int64 = input.readI64();
+                        const value_2: Int64 = input.readI64();
                         _args.bigID = value_2;
                     }
                     else {


### PR DESCRIPTION
[browser.js](https://github.com/apache/thrift/blob/master/lib/nodejs/lib/thrift/browser.js) file in `apache/thrift` repository doesn't export `Int64` type in case of *nodejs* which will cause undefined type errors. This way we can't use the generated typescript files for clients.
This pull request creates an import for `Int64` type in the generated typescript files if there are any usage of such type in the thrift files.