### PR TITLE
fix: Correctly handle annotations that are not valid identifiers

### DIFF
--- a/src/main/render/thrift-server/annotations.ts
+++ b/src/main/render/thrift-server/annotations.ts
@@ -11,13 +11,17 @@ import {
     THRIFT_IDENTIFIERS,
 } from './identifiers'
 
+const validIdentifierPattern = /^[a-z$_][0-9a-z$_]*$/i
+
 function renderAnnotationValue(annotations?: Annotations): ts.ObjectLiteralExpression {
     return ts.createObjectLiteral(
         (
             annotations !== undefined
                 ? annotations.annotations.map((annotation: Annotation) => {
+                    const name = annotation.name.value
+                    const identifier = validIdentifierPattern.test(name) ? name : `'${annotation.name.value}'`
                     return ts.createPropertyAssignment(
-                        ts.createIdentifier(annotation.name.value),
+                        identifier,
                         annotation.value !== undefined
                             ? ts.createLiteral(annotation.value.value)
                             : ts.createLiteral(''),

--- a/src/tests/unit/fixtures/thrift-server/annotations_exception.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/annotations_exception.solution.ts
@@ -75,13 +75,17 @@ export class MyException extends thrift.StructLike implements IMyException {
     public readonly _annotations: thrift.IThriftAnnotations = {
         foo: "bar",
         two: "three",
-        alone: ""
+        alone: "",
+        'dot.foo': "bar",
+        'dot.lonely': ""
     };
     public readonly _fieldAnnotations: thrift.IFieldAnnotations = {
         message: {
             foo: "bar",
             two: "three",
-            lonely: ""
+            lonely: "",
+            'dot.foo': "bar",
+            'dot.lonely': ""
         }
     };
     constructor(args: IMyExceptionArgs = {}) {

--- a/src/tests/unit/fixtures/thrift-server/annotations_service.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/annotations_service.solution.ts
@@ -117,14 +117,18 @@ export namespace MyService {
     export const annotations: thrift.IThriftAnnotations = {
         foo: "bar",
         two: "three",
-        alone: ""
+        alone: "",
+        'dot.foo': "bar",
+        'dot.lonely': ""
     };
     export const methodAnnotations: thrift.IMethodAnnotations = {
         getUser: {
             annotations: {
                 foo: "bar",
                 two: "three",
-                lonely: ""
+                lonely: "",
+                'dot.foo': "bar",
+                'dot.lonely': ""
             },
             fieldAnnotations: {}
         },

--- a/src/tests/unit/fixtures/thrift-server/annotations_struct.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/annotations_struct.solution.ts
@@ -80,13 +80,17 @@ export class MyStruct extends thrift.StructLike implements IMyStruct {
     public readonly _annotations: thrift.IThriftAnnotations = {
         foo: "bar",
         two: "three",
-        alone: ""
+        alone: "",
+        'dot.foo': "bar",
+        'dot.lonely': ""
     };
     public readonly _fieldAnnotations: thrift.IFieldAnnotations = {
         id: {
             foo: "bar",
             two: "three",
-            lonely: ""
+            lonely: "",
+            'dot.foo': "bar",
+            'dot.lonely': ""
         }
     };
     constructor(args: IMyStructArgs) {

--- a/src/tests/unit/fixtures/thrift-server/annotations_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/annotations_union.solution.ts
@@ -95,13 +95,17 @@ export class MyUnion extends thrift.StructLike implements IMyUnion {
     public readonly _annotations: thrift.IThriftAnnotations = {
         foo: "bar",
         two: "three",
-        alone: ""
+        alone: "",
+        'dot.foo': "bar",
+        'dot.lonely': ""
     };
     public readonly _fieldAnnotations: thrift.IFieldAnnotations = {
         field1: {
             foo: "bar",
             two: "three",
-            lonely: ""
+            lonely: "",
+            'dot.foo': "bar",
+            'dot.lonely': ""
         }
     };
     constructor(args: IMyUnionArgs = {}) {

--- a/src/tests/unit/index.spec.ts
+++ b/src/tests/unit/index.spec.ts
@@ -94,9 +94,9 @@ describe('Thrift TypeScript Generator', () => {
         it('should correctly generate a struct with annotations', () => {
             const content: string = `
                 struct MyStruct {
-                    1: required i32 id = 45 ( foo = "bar", two = "three", lonely )
+                    1: required i32 id = 45 ( foo = "bar", two = "three", lonely, dot.foo = "bar", dot.lonely )
                     2: required i64 bigID = 23948234
-                } ( foo = "bar", two = "three", alone )
+                } ( foo = "bar", two = "three", alone, dot.foo = "bar", dot.lonely )
             `
             const expected: string = readSolution('annotations_struct', 'thrift-server')
             const actual: string = make(content)
@@ -161,9 +161,9 @@ describe('Thrift TypeScript Generator', () => {
         it('should correctly generate a union with annotations', () => {
             const content: string = `
                 union MyUnion {
-                    1: i32 field1 ( foo = "bar", two = "three", lonely )
+                    1: i32 field1 ( foo = "bar", two = "three", lonely, dot.foo = "bar", dot.lonely )
                     2: i64 field2
-                } ( foo = "bar", two = "three", alone )
+                } ( foo = "bar", two = "three", alone, dot.foo = "bar", dot.lonely )
             `
             const expected: string = readSolution('annotations_union', 'thrift-server')
             const actual: string = make(content)
@@ -215,9 +215,9 @@ describe('Thrift TypeScript Generator', () => {
         it('should correctly generate an exception with annotations', () => {
             const content: string = `
                 exception MyException {
-                    1: string message ( foo = "bar", two = "three", lonely )
+                    1: string message ( foo = "bar", two = "three", lonely, dot.foo = "bar", dot.lonely )
                     2: i32 code = 200
-                } ( foo = "bar", two = "three", alone )
+                } ( foo = "bar", two = "three", alone, dot.foo = "bar", dot.lonely )
             `
             const expected: string = readSolution('annotations_exception', 'thrift-server')
             const actual: string = make(content)
@@ -283,10 +283,10 @@ describe('Thrift TypeScript Generator', () => {
                 }
 
                 service MyService {
-                    User getUser(1: i32 id) ( foo = "bar", two = "three", lonely )
+                    User getUser(1: i32 id) ( foo = "bar", two = "three", lonely, dot.foo = "bar", dot.lonely )
                     void saveUser(1: User user)
                     void ping()
-                } ( foo = "bar", two = "three", alone )
+                } ( foo = "bar", two = "three", alone, dot.foo = "bar", dot.lonely )
             `
             const expected: string = readSolution('annotations_service', 'thrift-server')
             const actual: string = make(content)


### PR DESCRIPTION
Currently annotation that are not valid javascript identifiers will render as invalid typescript when compiled for thrift-server.  This adds a simple check on the annotation name, and if it contains special characters that are not valid in a js identifier, it wraps the identifier in a string.  JS objects support any string as a key, so this should be 100% compatible with the way annotations are currently handled. 