### PR TITLE
fix: should import Int64 if i64 used as function argument

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1991 @@
+{
+    "name": "@creditkarma/thrift-typescript",
+    "version": "3.1.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@babel/code-frame": {
+            "version": "7.0.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@babel/code-frame/-/code-frame-7.0.0.tgz",
+            "integrity": "sha1-BuKrGb21NThVWaq7W6WXKUgoAPg=",
+            "dev": true,
+            "requires": {
+                "@babel/highlight": "^7.0.0"
+            }
+        },
+        "@babel/generator": {
+            "version": "7.3.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@babel/generator/-/generator-7.3.0.tgz",
+            "integrity": "sha1-9mODjNe1QjZt46pgimV7jMsqmes=",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.3.0",
+                "jsesc": "^2.5.1",
+                "lodash": "^4.17.10",
+                "source-map": "^0.5.0",
+                "trim-right": "^1.0.1"
+            }
+        },
+        "@babel/helper-function-name": {
+            "version": "7.1.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+            "integrity": "sha1-oM6wFoX3M1XUNgwSR/WCv6/I/1M=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-get-function-arity": "^7.0.0",
+                "@babel/template": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-get-function-arity": {
+            "version": "7.0.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+            "integrity": "sha1-g1ctQyDipGVyY3NBE8QoaLZOScM=",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-split-export-declaration": {
+            "version": "7.0.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+            "integrity": "sha1-Oq4oXAMRwqsJXZl7jJqUytVH2BM=",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/highlight": {
+            "version": "7.0.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@babel/highlight/-/highlight-7.0.0.tgz",
+            "integrity": "sha1-9xDDjI1Fjm3ZogGvtjf8t4HOmeQ=",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^4.0.0"
+            }
+        },
+        "@babel/parser": {
+            "version": "7.3.1",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@babel/parser/-/parser-7.3.1.tgz",
+            "integrity": "sha1-j0/9Rfd55hMngINf+nohX6Cy0YE=",
+            "dev": true
+        },
+        "@babel/template": {
+            "version": "7.2.2",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@babel/template/-/template-7.2.2.tgz",
+            "integrity": "sha1-AFs/3w7ZbogEEzA3ng2ppwjrKQc=",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/parser": "^7.2.2",
+                "@babel/types": "^7.2.2"
+            }
+        },
+        "@babel/traverse": {
+            "version": "7.2.3",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@babel/traverse/-/traverse-7.2.3.tgz",
+            "integrity": "sha1-f/UM76nHwL0tgSMf2sEi85V3SNg=",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/generator": "^7.2.2",
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-split-export-declaration": "^7.0.0",
+                "@babel/parser": "^7.2.3",
+                "@babel/types": "^7.2.2",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0",
+                "lodash": "^4.17.10"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/types": {
+            "version": "7.3.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@babel/types/-/types-7.3.0.tgz",
+            "integrity": "sha1-YdwLM2qTutwCv19pxM2OE1Py/8A=",
+            "dev": true,
+            "requires": {
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.10",
+                "to-fast-properties": "^2.0.0"
+            }
+        },
+        "@creditkarma/thrift-parser": {
+            "version": "1.1.4",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@creditkarma/thrift-parser/-/thrift-parser-1.1.4.tgz",
+            "integrity": "sha1-SSbZbEISrvjc5OrIc/arJ6pS9GQ="
+        },
+        "@types/chai": {
+            "version": "4.1.7",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@types/chai/-/chai-4.1.7.tgz",
+            "integrity": "sha1-G44zthqMCcvh+FEzBxuqDb+fpxo=",
+            "dev": true
+        },
+        "@types/events": {
+            "version": "3.0.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@types/events/-/events-3.0.0.tgz",
+            "integrity": "sha1-KGLz9Yqaf3w+eNefEw3U1xwlwqc=",
+            "dev": true
+        },
+        "@types/glob": {
+            "version": "7.1.1",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@types/glob/-/glob-7.1.1.tgz",
+            "integrity": "sha1-qlmhxuP7xCHgfM0xqUTDDrpSFXU=",
+            "dev": true,
+            "requires": {
+                "@types/events": "*",
+                "@types/minimatch": "*",
+                "@types/node": "*"
+            }
+        },
+        "@types/minimatch": {
+            "version": "3.0.3",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@types/minimatch/-/minimatch-3.0.3.tgz",
+            "integrity": "sha1-PcoOPzOyAPx9ETnAzZbBJoyt/Z0=",
+            "dev": true
+        },
+        "@types/mocha": {
+            "version": "5.2.5",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@types/mocha/-/mocha-5.2.5.tgz",
+            "integrity": "sha1-ikrM/EA8EkoLr+ip/GGgXsEDIHM=",
+            "dev": true
+        },
+        "@types/node": {
+            "version": "8.10.39",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@types/node/-/node-8.10.39.tgz",
+            "integrity": "sha1-5+h60ANk3XvEhclAkmNFuOwaJso=",
+            "dev": true
+        },
+        "@types/node-int64": {
+            "version": "0.4.29",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@types/node-int64/-/node-int64-0.4.29.tgz",
+            "integrity": "sha1-jHwWp8EZWuT4vqqQOwAYrGYpHRY=",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@types/q": {
+            "version": "1.5.1",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@types/q/-/q-1.5.1.tgz",
+            "integrity": "sha1-SP2YwVYf5xi2FzPa7Ub/EVtJbhg=",
+            "dev": true
+        },
+        "@types/rimraf": {
+            "version": "2.0.2",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@types/rimraf/-/rimraf-2.0.2.tgz",
+            "integrity": "sha1-fw/Dzw/wrSqZu3I64XZPMKyvi24=",
+            "dev": true,
+            "requires": {
+                "@types/glob": "*",
+                "@types/node": "*"
+            }
+        },
+        "@types/thrift": {
+            "version": "0.10.7",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@types/thrift/-/thrift-0.10.7.tgz",
+            "integrity": "sha1-qAwDJIL6juGLiF2/Q91PldG3MIo=",
+            "dev": true,
+            "requires": {
+                "@types/node": "*",
+                "@types/node-int64": "*",
+                "@types/q": "*"
+            }
+        },
+        "ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "dev": true
+        },
+        "ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+            "dev": true,
+            "requires": {
+                "color-convert": "^1.9.0"
+            }
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "assertion-error": {
+            "version": "1.1.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/assertion-error/-/assertion-error-1.1.0.tgz",
+            "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs=",
+            "dev": true
+        },
+        "async-limiter": {
+            "version": "1.0.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/async-limiter/-/async-limiter-1.0.0.tgz",
+            "integrity": "sha1-ePrtjD0HSrgfIrTphdeehzj3IPg=",
+            "dev": true
+        },
+        "babel-code-frame": {
+            "version": "6.26.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+            "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+            "dev": true,
+            "requires": {
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                },
+                "js-tokens": {
+                    "version": "3.0.2",
+                    "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/js-tokens/-/js-tokens-3.0.2.tgz",
+                    "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "browser-stdout": {
+            "version": "1.3.1",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/browser-stdout/-/browser-stdout-1.3.1.tgz",
+            "integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA=",
+            "dev": true
+        },
+        "buffer-from": {
+            "version": "1.1.1",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
+            "dev": true
+        },
+        "builtin-modules": {
+            "version": "1.1.1",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/builtin-modules/-/builtin-modules-1.1.1.tgz",
+            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+            "dev": true
+        },
+        "chai": {
+            "version": "4.2.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/chai/-/chai-4.2.0.tgz",
+            "integrity": "sha1-dgqnLPION5XoSxKHfODoNzeqKeU=",
+            "dev": true,
+            "requires": {
+                "assertion-error": "^1.1.0",
+                "check-error": "^1.0.2",
+                "deep-eql": "^3.0.1",
+                "get-func-name": "^2.0.0",
+                "pathval": "^1.1.0",
+                "type-detect": "^4.0.5"
+            }
+        },
+        "chalk": {
+            "version": "2.4.2",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            }
+        },
+        "check-error": {
+            "version": "1.0.2",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/check-error/-/check-error-1.0.2.tgz",
+            "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+            "dev": true
+        },
+        "color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+            "dev": true,
+            "requires": {
+                "color-name": "1.1.3"
+            }
+        },
+        "color-name": {
+            "version": "1.1.3",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "commander": {
+            "version": "2.15.1",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/commander/-/commander-2.15.1.tgz",
+            "integrity": "sha1-30boZ9D8Kuxmo0ZitAapzK//Ww8=",
+            "dev": true
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "debug": {
+            "version": "3.1.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/debug/-/debug-3.1.0.tgz",
+            "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+            "dev": true,
+            "requires": {
+                "ms": "2.0.0"
+            }
+        },
+        "deep-eql": {
+            "version": "3.0.1",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/deep-eql/-/deep-eql-3.0.1.tgz",
+            "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
+            "dev": true,
+            "requires": {
+                "type-detect": "^4.0.0"
+            }
+        },
+        "diff": {
+            "version": "3.5.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/diff/-/diff-3.5.0.tgz",
+            "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI=",
+            "dev": true
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "eslint-plugin-prettier": {
+            "version": "2.7.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/eslint-plugin-prettier/-/eslint-plugin-prettier-2.7.0.tgz",
+            "integrity": "sha1-tDEtzywdllN51/nVtfiqrcakWQQ=",
+            "dev": true,
+            "requires": {
+                "fast-diff": "^1.1.1",
+                "jest-docblock": "^21.0.0"
+            }
+        },
+        "esprima": {
+            "version": "4.0.1",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
+            "dev": true
+        },
+        "esutils": {
+            "version": "2.0.2",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/esutils/-/esutils-2.0.2.tgz",
+            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+            "dev": true
+        },
+        "fast-diff": {
+            "version": "1.2.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/fast-diff/-/fast-diff-1.2.0.tgz",
+            "integrity": "sha1-c+4RmC2Gyq95WYKNUZz+kn+sXwM=",
+            "dev": true
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+        },
+        "get-func-name": {
+            "version": "2.0.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/get-func-name/-/get-func-name-2.0.0.tgz",
+            "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+            "dev": true
+        },
+        "glob": {
+            "version": "7.1.3",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/glob/-/glob-7.1.3.tgz",
+            "integrity": "sha1-OWCDLT8VdBCDQtr9OmezMsCWnfE=",
+            "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            }
+        },
+        "globals": {
+            "version": "11.10.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/globals/-/globals-11.10.0.tgz",
+            "integrity": "sha1-Hgl3bf/aXgGBazu0B3yLWcJOqlA=",
+            "dev": true
+        },
+        "growl": {
+            "version": "1.10.5",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/growl/-/growl-1.10.5.tgz",
+            "integrity": "sha1-8nNdwig2dPpnR4sQGBBZNVw2nl4=",
+            "dev": true
+        },
+        "has-ansi": {
+            "version": "2.0.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/has-ansi/-/has-ansi-2.0.0.tgz",
+            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "^2.0.0"
+            }
+        },
+        "has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true
+        },
+        "he": {
+            "version": "1.1.1",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/he/-/he-1.1.1.tgz",
+            "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+            "dev": true
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "inherits": {
+            "version": "2.0.3",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "istanbul-lib-coverage": {
+            "version": "2.0.1",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+            "integrity": "sha1-Ku4OBzrYxfagsA4N+/UrRmdHLto=",
+            "dev": true
+        },
+        "istanbul-lib-instrument": {
+            "version": "3.0.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/istanbul-lib-instrument/-/istanbul-lib-instrument-3.0.0.tgz",
+            "integrity": "sha1-tfBmsqFh91eIvhep1Vb0Cgzyr8k=",
+            "dev": true,
+            "requires": {
+                "@babel/generator": "^7.0.0",
+                "@babel/parser": "^7.0.0",
+                "@babel/template": "^7.0.0",
+                "@babel/traverse": "^7.0.0",
+                "@babel/types": "^7.0.0",
+                "istanbul-lib-coverage": "^2.0.1",
+                "semver": "^5.5.0"
+            }
+        },
+        "jest-docblock": {
+            "version": "21.2.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/jest-docblock/-/jest-docblock-21.2.0.tgz",
+            "integrity": "sha1-UVKcOzDV/RWdpgwnzu3Blfr41BQ=",
+            "dev": true
+        },
+        "js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
+            "dev": true
+        },
+        "js-yaml": {
+            "version": "3.12.1",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/js-yaml/-/js-yaml-3.12.1.tgz",
+            "integrity": "sha1-KVyGMqGKI+BUz1ydPOyv5ngWdgA=",
+            "dev": true,
+            "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            }
+        },
+        "jsesc": {
+            "version": "2.5.2",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/jsesc/-/jsesc-2.5.2.tgz",
+            "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
+            "dev": true
+        },
+        "lines-and-columns": {
+            "version": "1.1.6",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+            "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+            "dev": true
+        },
+        "lodash": {
+            "version": "4.17.11",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/lodash/-/lodash-4.17.11.tgz",
+            "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40=",
+            "dev": true
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
+        "minimist": {
+            "version": "0.0.8",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/minimist/-/minimist-0.0.8.tgz",
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+            "dev": true
+        },
+        "mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "dev": true,
+            "requires": {
+                "minimist": "0.0.8"
+            }
+        },
+        "mocha": {
+            "version": "5.2.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/mocha/-/mocha-5.2.0.tgz",
+            "integrity": "sha1-bYrlCPWRZ/lA8rWzxKYSrlDJCuY=",
+            "dev": true,
+            "requires": {
+                "browser-stdout": "1.3.1",
+                "commander": "2.15.1",
+                "debug": "3.1.0",
+                "diff": "3.5.0",
+                "escape-string-regexp": "1.0.5",
+                "glob": "7.1.2",
+                "growl": "1.10.5",
+                "he": "1.1.1",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "supports-color": "5.4.0"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "7.1.2",
+                    "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                }
+            }
+        },
+        "ms": {
+            "version": "2.0.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
+        },
+        "node-int64": {
+            "version": "0.4.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/node-int64/-/node-int64-0.4.0.tgz",
+            "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+            "dev": true
+        },
+        "nyc": {
+            "version": "13.1.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/nyc/-/nyc-13.1.0.tgz",
+            "integrity": "sha1-RjZlx/9rV5jjImJKXrRJpnjbkOM=",
+            "dev": true,
+            "requires": {
+                "archy": "^1.0.0",
+                "arrify": "^1.0.1",
+                "caching-transform": "^2.0.0",
+                "convert-source-map": "^1.6.0",
+                "debug-log": "^1.0.1",
+                "find-cache-dir": "^2.0.0",
+                "find-up": "^3.0.0",
+                "foreground-child": "^1.5.6",
+                "glob": "^7.1.3",
+                "istanbul-lib-coverage": "^2.0.1",
+                "istanbul-lib-hook": "^2.0.1",
+                "istanbul-lib-instrument": "^3.0.0",
+                "istanbul-lib-report": "^2.0.2",
+                "istanbul-lib-source-maps": "^2.0.1",
+                "istanbul-reports": "^2.0.1",
+                "make-dir": "^1.3.0",
+                "merge-source-map": "^1.1.0",
+                "resolve-from": "^4.0.0",
+                "rimraf": "^2.6.2",
+                "signal-exit": "^3.0.2",
+                "spawn-wrap": "^1.4.2",
+                "test-exclude": "^5.0.0",
+                "uuid": "^3.3.2",
+                "yargs": "11.1.0",
+                "yargs-parser": "^9.0.2"
+            },
+            "dependencies": {
+                "align-text": {
+                    "version": "0.1.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^3.0.2",
+                        "longest": "^1.0.1",
+                        "repeat-string": "^1.5.2"
+                    }
+                },
+                "amdefine": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "append-transform": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "default-require-extensions": "^2.0.0"
+                    }
+                },
+                "archy": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "arrify": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "async": {
+                    "version": "1.5.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "brace-expansion": {
+                    "version": "1.1.11",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "builtin-modules": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "caching-transform": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "make-dir": "^1.0.0",
+                        "md5-hex": "^2.0.0",
+                        "package-hash": "^2.0.0",
+                        "write-file-atomic": "^2.0.0"
+                    }
+                },
+                "camelcase": {
+                    "version": "1.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "center-align": {
+                    "version": "0.1.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "align-text": "^0.1.3",
+                        "lazy-cache": "^1.0.3"
+                    }
+                },
+                "cliui": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "center-align": "^0.1.1",
+                        "right-align": "^0.1.1",
+                        "wordwrap": "0.0.2"
+                    },
+                    "dependencies": {
+                        "wordwrap": {
+                            "version": "0.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "code-point-at": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "commondir": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "convert-source-map": {
+                    "version": "1.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.1"
+                    }
+                },
+                "cross-spawn": {
+                    "version": "4.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^4.0.1",
+                        "which": "^1.2.9"
+                    }
+                },
+                "debug": {
+                    "version": "3.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "debug-log": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "decamelize": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "default-require-extensions": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "strip-bom": "^3.0.0"
+                    }
+                },
+                "error-ex": {
+                    "version": "1.3.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "is-arrayish": "^0.2.1"
+                    }
+                },
+                "es6-error": {
+                    "version": "4.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "execa": {
+                    "version": "0.7.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "cross-spawn": {
+                            "version": "5.1.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "lru-cache": "^4.0.1",
+                                "shebang-command": "^1.2.0",
+                                "which": "^1.2.9"
+                            }
+                        }
+                    }
+                },
+                "find-cache-dir": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "commondir": "^1.0.1",
+                        "make-dir": "^1.0.0",
+                        "pkg-dir": "^3.0.0"
+                    }
+                },
+                "find-up": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "foreground-child": {
+                    "version": "1.5.6",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^4",
+                        "signal-exit": "^3.0.0"
+                    }
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "get-caller-file": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "get-stream": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "glob": {
+                    "version": "7.1.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.1.11",
+                    "bundled": true,
+                    "dev": true
+                },
+                "handlebars": {
+                    "version": "4.0.11",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "async": "^1.4.0",
+                        "optimist": "^0.6.1",
+                        "source-map": "^0.4.4",
+                        "uglify-js": "^2.6"
+                    },
+                    "dependencies": {
+                        "source-map": {
+                            "version": "0.4.4",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "amdefine": ">=0.0.4"
+                            }
+                        }
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "hosted-git-info": {
+                    "version": "2.7.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "imurmurhash": {
+                    "version": "0.1.4",
+                    "bundled": true,
+                    "dev": true
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "once": "^1.3.0",
+                        "wrappy": "1"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "invert-kv": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-arrayish": {
+                    "version": "0.2.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-buffer": {
+                    "version": "1.1.6",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-builtin-module": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "builtin-modules": "^1.0.0"
+                    }
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-stream": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "isexe": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "istanbul-lib-coverage": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "istanbul-lib-hook": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "append-transform": "^1.0.0"
+                    }
+                },
+                "istanbul-lib-report": {
+                    "version": "2.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "istanbul-lib-coverage": "^2.0.1",
+                        "make-dir": "^1.3.0",
+                        "supports-color": "^5.4.0"
+                    }
+                },
+                "istanbul-lib-source-maps": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "debug": "^3.1.0",
+                        "istanbul-lib-coverage": "^2.0.1",
+                        "make-dir": "^1.3.0",
+                        "rimraf": "^2.6.2",
+                        "source-map": "^0.6.1"
+                    },
+                    "dependencies": {
+                        "source-map": {
+                            "version": "0.6.1",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "istanbul-reports": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "handlebars": "^4.0.11"
+                    }
+                },
+                "json-parse-better-errors": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                },
+                "lazy-cache": {
+                    "version": "1.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "lcid": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "invert-kv": "^1.0.0"
+                    }
+                },
+                "load-json-file": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^4.0.0",
+                        "pify": "^3.0.0",
+                        "strip-bom": "^3.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "lodash.flattendeep": {
+                    "version": "4.4.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "longest": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lru-cache": {
+                    "version": "4.1.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
+                    }
+                },
+                "make-dir": {
+                    "version": "1.3.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "pify": "^3.0.0"
+                    }
+                },
+                "md5-hex": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "md5-o-matic": "^0.1.1"
+                    }
+                },
+                "md5-o-matic": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "mem": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "mimic-fn": "^1.0.0"
+                    }
+                },
+                "merge-source-map": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "source-map": "^0.6.1"
+                    },
+                    "dependencies": {
+                        "source-map": {
+                            "version": "0.6.1",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "mimic-fn": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                },
+                "minimist": {
+                    "version": "0.0.10",
+                    "bundled": true,
+                    "dev": true
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    },
+                    "dependencies": {
+                        "minimist": {
+                            "version": "0.0.8",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "normalize-package-data": {
+                    "version": "2.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "hosted-git-info": "^2.1.4",
+                        "is-builtin-module": "^1.0.0",
+                        "semver": "2 || 3 || 4 || 5",
+                        "validate-npm-package-license": "^3.0.1"
+                    }
+                },
+                "npm-run-path": {
+                    "version": "2.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "path-key": "^2.0.0"
+                    }
+                },
+                "number-is-nan": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "wrappy": "1"
+                    }
+                },
+                "optimist": {
+                    "version": "0.6.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minimist": "~0.0.1",
+                        "wordwrap": "~0.0.2"
+                    }
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "os-locale": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "execa": "^0.7.0",
+                        "lcid": "^1.0.0",
+                        "mem": "^1.1.0"
+                    }
+                },
+                "p-finally": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "p-limit": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "package-hash": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.11",
+                        "lodash.flattendeep": "^4.4.0",
+                        "md5-hex": "^2.0.0",
+                        "release-zalgo": "^1.0.0"
+                    }
+                },
+                "parse-json": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1"
+                    }
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "path-key": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "path-type": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "pify": "^3.0.0"
+                    }
+                },
+                "pify": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "pkg-dir": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^3.0.0"
+                    }
+                },
+                "pseudomap": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "read-pkg": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "load-json-file": "^4.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^3.0.0"
+                    }
+                },
+                "read-pkg-up": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^3.0.0",
+                        "read-pkg": "^3.0.0"
+                    }
+                },
+                "release-zalgo": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "es6-error": "^4.0.1"
+                    }
+                },
+                "repeat-string": {
+                    "version": "1.6.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "require-directory": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "require-main-filename": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "resolve-from": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "right-align": {
+                    "version": "0.1.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "align-text": "^0.1.1"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.6.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.0.5"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "semver": {
+                    "version": "5.5.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "set-blocking": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "shebang-command": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "shebang-regex": "^1.0.0"
+                    }
+                },
+                "shebang-regex": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "signal-exit": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "spawn-wrap": {
+                    "version": "1.4.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "foreground-child": "^1.5.6",
+                        "mkdirp": "^0.5.0",
+                        "os-homedir": "^1.0.1",
+                        "rimraf": "^2.6.2",
+                        "signal-exit": "^3.0.2",
+                        "which": "^1.3.0"
+                    }
+                },
+                "spdx-correct": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "spdx-expression-parse": "^3.0.0",
+                        "spdx-license-ids": "^3.0.0"
+                    }
+                },
+                "spdx-exceptions": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "spdx-expression-parse": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "spdx-exceptions": "^2.1.0",
+                        "spdx-license-ids": "^3.0.0"
+                    }
+                },
+                "spdx-license-ids": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                },
+                "strip-bom": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "strip-eof": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                },
+                "test-exclude": {
+                    "version": "5.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "arrify": "^1.0.1",
+                        "minimatch": "^3.0.4",
+                        "read-pkg-up": "^4.0.0",
+                        "require-main-filename": "^1.0.1"
+                    }
+                },
+                "uglify-js": {
+                    "version": "2.8.29",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "source-map": "~0.5.1",
+                        "uglify-to-browserify": "~1.0.0",
+                        "yargs": "~3.10.0"
+                    },
+                    "dependencies": {
+                        "yargs": {
+                            "version": "3.10.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "camelcase": "^1.0.2",
+                                "cliui": "^2.1.0",
+                                "decamelize": "^1.0.0",
+                                "window-size": "0.1.0"
+                            }
+                        }
+                    }
+                },
+                "uglify-to-browserify": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "uuid": {
+                    "version": "3.3.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "validate-npm-package-license": {
+                    "version": "3.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "spdx-correct": "^3.0.0",
+                        "spdx-expression-parse": "^3.0.0"
+                    }
+                },
+                "which": {
+                    "version": "1.3.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                },
+                "which-module": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "window-size": {
+                    "version": "0.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "wordwrap": {
+                    "version": "0.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "wrap-ansi": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "2.1.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "is-fullwidth-code-point": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "number-is-nan": "^1.0.0"
+                            }
+                        },
+                        "string-width": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "code-point-at": "^1.0.0",
+                                "is-fullwidth-code-point": "^1.0.0",
+                                "strip-ansi": "^3.0.0"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "3.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^2.0.0"
+                            }
+                        }
+                    }
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "write-file-atomic": {
+                    "version": "2.3.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.11",
+                        "imurmurhash": "^0.1.4",
+                        "signal-exit": "^3.0.2"
+                    }
+                },
+                "y18n": {
+                    "version": "3.2.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "yallist": {
+                    "version": "2.1.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "11.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^4.0.0",
+                        "decamelize": "^1.1.1",
+                        "find-up": "^2.1.0",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^2.0.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^2.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^9.0.2"
+                    },
+                    "dependencies": {
+                        "cliui": {
+                            "version": "4.1.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "string-width": "^2.1.1",
+                                "strip-ansi": "^4.0.0",
+                                "wrap-ansi": "^2.0.0"
+                            }
+                        },
+                        "find-up": {
+                            "version": "2.1.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "locate-path": "^2.0.0"
+                            }
+                        },
+                        "locate-path": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "p-locate": "^2.0.0",
+                                "path-exists": "^3.0.0"
+                            }
+                        },
+                        "p-limit": {
+                            "version": "1.3.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "p-try": "^1.0.0"
+                            }
+                        },
+                        "p-locate": {
+                            "version": "2.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "p-limit": "^1.1.0"
+                            }
+                        },
+                        "p-try": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "yargs-parser": {
+                    "version": "9.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^4.1.0"
+                    },
+                    "dependencies": {
+                        "camelcase": {
+                            "version": "4.1.0",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                }
+            }
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "requires": {
+                "wrappy": "1"
+            }
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+        },
+        "path-parse": {
+            "version": "1.0.6",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/path-parse/-/path-parse-1.0.6.tgz",
+            "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
+            "dev": true
+        },
+        "pathval": {
+            "version": "1.1.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/pathval/-/pathval-1.1.0.tgz",
+            "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+            "dev": true
+        },
+        "prettier": {
+            "version": "1.16.1",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/prettier/-/prettier-1.16.1.tgz",
+            "integrity": "sha1-U0wsnXhT+IReXgeDhOcZc710CJ8=",
+            "dev": true
+        },
+        "q": {
+            "version": "1.5.1",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/q/-/q-1.5.1.tgz",
+            "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+            "dev": true
+        },
+        "resolve": {
+            "version": "1.10.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/resolve/-/resolve-1.10.0.tgz",
+            "integrity": "sha1-O9qur0XMB/N1ZW39LlTtCBCxAbo=",
+            "dev": true,
+            "requires": {
+                "path-parse": "^1.0.6"
+            }
+        },
+        "rimraf": {
+            "version": "2.6.3",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/rimraf/-/rimraf-2.6.3.tgz",
+            "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.3"
+            }
+        },
+        "semver": {
+            "version": "5.6.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/semver/-/semver-5.6.0.tgz",
+            "integrity": "sha1-fnQlb7qknHWqfHogXMInmcrIAAQ=",
+            "dev": true
+        },
+        "source-map": {
+            "version": "0.5.7",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+            "dev": true
+        },
+        "source-map-support": {
+            "version": "0.5.10",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/source-map-support/-/source-map-support-0.5.10.tgz",
+            "integrity": "sha1-IhQIC8nVGDJRHuK6uW48L5NTEgw=",
+            "dev": true,
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+                    "dev": true
+                }
+            }
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
+        "strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "^2.0.0"
+            }
+        },
+        "supports-color": {
+            "version": "5.4.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/supports-color/-/supports-color-5.4.0.tgz",
+            "integrity": "sha1-HGszdALCE3YF7+GfEP7DkPb6q1Q=",
+            "dev": true,
+            "requires": {
+                "has-flag": "^3.0.0"
+            }
+        },
+        "thrift": {
+            "version": "0.11.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/thrift/-/thrift-0.11.0.tgz",
+            "integrity": "sha1-JWEV5P+Hhx4SU39LUQvStCXhOZA=",
+            "dev": true,
+            "requires": {
+                "node-int64": "^0.4.0",
+                "q": "^1.5.0",
+                "ws": ">= 2.2.3"
+            }
+        },
+        "to-fast-properties": {
+            "version": "2.0.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+            "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+            "dev": true
+        },
+        "trim-right": {
+            "version": "1.0.1",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/trim-right/-/trim-right-1.0.1.tgz",
+            "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+            "dev": true
+        },
+        "tslib": {
+            "version": "1.9.3",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/tslib/-/tslib-1.9.3.tgz",
+            "integrity": "sha1-1+TdeSRdhUKMTX5IIqeZF5VMooY=",
+            "dev": true
+        },
+        "tslint": {
+            "version": "5.12.1",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/tslint/-/tslint-5.12.1.tgz",
+            "integrity": "sha1-jOydRUz4od6bCibXvbrW3jYuUsE=",
+            "dev": true,
+            "requires": {
+                "babel-code-frame": "^6.22.0",
+                "builtin-modules": "^1.1.1",
+                "chalk": "^2.3.0",
+                "commander": "^2.12.1",
+                "diff": "^3.2.0",
+                "glob": "^7.1.1",
+                "js-yaml": "^3.7.0",
+                "minimatch": "^3.0.4",
+                "resolve": "^1.3.2",
+                "semver": "^5.3.0",
+                "tslib": "^1.8.0",
+                "tsutils": "^2.27.2"
+            }
+        },
+        "tslint-config-prettier": {
+            "version": "1.17.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/tslint-config-prettier/-/tslint-config-prettier-1.17.0.tgz",
+            "integrity": "sha1-lG7WEX+Y82WaZYSCeRVth2KMM9w=",
+            "dev": true
+        },
+        "tslint-plugin-prettier": {
+            "version": "2.0.1",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/tslint-plugin-prettier/-/tslint-plugin-prettier-2.0.1.tgz",
+            "integrity": "sha1-lbajt2ZiL/xEN1gl13YCJcUMNoA=",
+            "dev": true,
+            "requires": {
+                "eslint-plugin-prettier": "^2.2.0",
+                "lines-and-columns": "^1.1.6",
+                "tslib": "^1.7.1"
+            }
+        },
+        "tsutils": {
+            "version": "2.29.0",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/tsutils/-/tsutils-2.29.0.tgz",
+            "integrity": "sha1-MrSIUBRnrL7dS4VJhnOggSrKC5k=",
+            "dev": true,
+            "requires": {
+                "tslib": "^1.8.1"
+            }
+        },
+        "type-detect": {
+            "version": "4.0.8",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/type-detect/-/type-detect-4.0.8.tgz",
+            "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
+            "dev": true
+        },
+        "typescript": {
+            "version": "3.2.4",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/typescript/-/typescript-3.2.4.tgz",
+            "integrity": "sha1-xYXLlSkSJj2RW0YnJs4kS6UQ7z0="
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        },
+        "ws": {
+            "version": "6.1.3",
+            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/ws/-/ws-6.1.3.tgz",
+            "integrity": "sha1-0tLl8OPHAO8t6JCA68Csbhvzpy0=",
+            "dev": true,
+            "requires": {
+                "async-limiter": "~1.0.0"
+            }
+        }
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,8 +6,8 @@
     "dependencies": {
         "@babel/code-frame": {
             "version": "7.0.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@babel/code-frame/-/code-frame-7.0.0.tgz",
-            "integrity": "sha1-BuKrGb21NThVWaq7W6WXKUgoAPg=",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+            "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
             "dev": true,
             "requires": {
                 "@babel/highlight": "^7.0.0"
@@ -15,8 +15,8 @@
         },
         "@babel/generator": {
             "version": "7.3.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@babel/generator/-/generator-7.3.0.tgz",
-            "integrity": "sha1-9mODjNe1QjZt46pgimV7jMsqmes=",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.0.tgz",
+            "integrity": "sha512-dZTwMvTgWfhmibq4V9X+LMf6Bgl7zAodRn9PvcPdhlzFMbvUutx74dbEv7Atz3ToeEpevYEJtAwfxq/bDCzHWg==",
             "dev": true,
             "requires": {
                 "@babel/types": "^7.3.0",
@@ -28,8 +28,8 @@
         },
         "@babel/helper-function-name": {
             "version": "7.1.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-            "integrity": "sha1-oM6wFoX3M1XUNgwSR/WCv6/I/1M=",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+            "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
             "dev": true,
             "requires": {
                 "@babel/helper-get-function-arity": "^7.0.0",
@@ -39,8 +39,8 @@
         },
         "@babel/helper-get-function-arity": {
             "version": "7.0.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-            "integrity": "sha1-g1ctQyDipGVyY3NBE8QoaLZOScM=",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+            "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
             "dev": true,
             "requires": {
                 "@babel/types": "^7.0.0"
@@ -48,8 +48,8 @@
         },
         "@babel/helper-split-export-declaration": {
             "version": "7.0.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
-            "integrity": "sha1-Oq4oXAMRwqsJXZl7jJqUytVH2BM=",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+            "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
             "dev": true,
             "requires": {
                 "@babel/types": "^7.0.0"
@@ -57,8 +57,8 @@
         },
         "@babel/highlight": {
             "version": "7.0.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@babel/highlight/-/highlight-7.0.0.tgz",
-            "integrity": "sha1-9xDDjI1Fjm3ZogGvtjf8t4HOmeQ=",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+            "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
             "dev": true,
             "requires": {
                 "chalk": "^2.0.0",
@@ -68,14 +68,14 @@
         },
         "@babel/parser": {
             "version": "7.3.1",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@babel/parser/-/parser-7.3.1.tgz",
-            "integrity": "sha1-j0/9Rfd55hMngINf+nohX6Cy0YE=",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.1.tgz",
+            "integrity": "sha512-ATz6yX/L8LEnC3dtLQnIx4ydcPxhLcoy9Vl6re00zb2w5lG6itY6Vhnr1KFRPq/FHNsgl/gh2mjNN20f9iJTTA==",
             "dev": true
         },
         "@babel/template": {
             "version": "7.2.2",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@babel/template/-/template-7.2.2.tgz",
-            "integrity": "sha1-AFs/3w7ZbogEEzA3ng2ppwjrKQc=",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
+            "integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
@@ -85,8 +85,8 @@
         },
         "@babel/traverse": {
             "version": "7.2.3",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@babel/traverse/-/traverse-7.2.3.tgz",
-            "integrity": "sha1-f/UM76nHwL0tgSMf2sEi85V3SNg=",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.2.3.tgz",
+            "integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
@@ -102,8 +102,8 @@
             "dependencies": {
                 "debug": {
                     "version": "4.1.1",
-                    "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
                     "dev": true,
                     "requires": {
                         "ms": "^2.1.1"
@@ -111,16 +111,16 @@
                 },
                 "ms": {
                     "version": "2.1.1",
-                    "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/ms/-/ms-2.1.1.tgz",
-                    "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo=",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
                     "dev": true
                 }
             }
         },
         "@babel/types": {
             "version": "7.3.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@babel/types/-/types-7.3.0.tgz",
-            "integrity": "sha1-YdwLM2qTutwCv19pxM2OE1Py/8A=",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.0.tgz",
+            "integrity": "sha512-QkFPw68QqWU1/RVPyBe8SO7lXbPfjtqAxRYQKpFpaB8yMq7X2qAqfwK5LKoQufEkSmO5NQ70O6Kc3Afk03RwXw==",
             "dev": true,
             "requires": {
                 "esutils": "^2.0.2",
@@ -130,25 +130,25 @@
         },
         "@creditkarma/thrift-parser": {
             "version": "1.1.4",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@creditkarma/thrift-parser/-/thrift-parser-1.1.4.tgz",
+            "resolved": "https://registry.npmjs.org/@creditkarma/thrift-parser/-/thrift-parser-1.1.4.tgz",
             "integrity": "sha1-SSbZbEISrvjc5OrIc/arJ6pS9GQ="
         },
         "@types/chai": {
             "version": "4.1.7",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@types/chai/-/chai-4.1.7.tgz",
-            "integrity": "sha1-G44zthqMCcvh+FEzBxuqDb+fpxo=",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.7.tgz",
+            "integrity": "sha512-2Y8uPt0/jwjhQ6EiluT0XCri1Dbplr0ZxfFXUz+ye13gaqE8u5gL5ppao1JrUYr9cIip5S6MvQzBS7Kke7U9VA==",
             "dev": true
         },
         "@types/events": {
             "version": "3.0.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@types/events/-/events-3.0.0.tgz",
-            "integrity": "sha1-KGLz9Yqaf3w+eNefEw3U1xwlwqc=",
+            "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+            "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
             "dev": true
         },
         "@types/glob": {
             "version": "7.1.1",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@types/glob/-/glob-7.1.1.tgz",
-            "integrity": "sha1-qlmhxuP7xCHgfM0xqUTDDrpSFXU=",
+            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+            "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
             "dev": true,
             "requires": {
                 "@types/events": "*",
@@ -158,26 +158,26 @@
         },
         "@types/minimatch": {
             "version": "3.0.3",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@types/minimatch/-/minimatch-3.0.3.tgz",
-            "integrity": "sha1-PcoOPzOyAPx9ETnAzZbBJoyt/Z0=",
+            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+            "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
             "dev": true
         },
         "@types/mocha": {
             "version": "5.2.5",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@types/mocha/-/mocha-5.2.5.tgz",
-            "integrity": "sha1-ikrM/EA8EkoLr+ip/GGgXsEDIHM=",
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.5.tgz",
+            "integrity": "sha512-lAVp+Kj54ui/vLUFxsJTMtWvZraZxum3w3Nwkble2dNuV5VnPA+Mi2oGX9XYJAaIvZi3tn3cbjS/qcJXRb6Bww==",
             "dev": true
         },
         "@types/node": {
             "version": "8.10.39",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@types/node/-/node-8.10.39.tgz",
-            "integrity": "sha1-5+h60ANk3XvEhclAkmNFuOwaJso=",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.39.tgz",
+            "integrity": "sha512-rE7fktr02J8ybFf6eysife+WF+L4sAHWzw09DgdCebEu+qDwMvv4zl6Bc+825ttGZP73kCKxa3dhJOoGJ8+5mA==",
             "dev": true
         },
         "@types/node-int64": {
             "version": "0.4.29",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@types/node-int64/-/node-int64-0.4.29.tgz",
-            "integrity": "sha1-jHwWp8EZWuT4vqqQOwAYrGYpHRY=",
+            "resolved": "https://registry.npmjs.org/@types/node-int64/-/node-int64-0.4.29.tgz",
+            "integrity": "sha512-rHXvenLTj/CcsmNAebaBOhxQ2MqEGl3yXZZcZ21XYR+gzGTTcpOy2N4IxpvTCz48loyQNatHvfn6GhIbbZ1R3Q==",
             "dev": true,
             "requires": {
                 "@types/node": "*"
@@ -185,14 +185,14 @@
         },
         "@types/q": {
             "version": "1.5.1",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@types/q/-/q-1.5.1.tgz",
-            "integrity": "sha1-SP2YwVYf5xi2FzPa7Ub/EVtJbhg=",
+            "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.1.tgz",
+            "integrity": "sha512-eqz8c/0kwNi/OEHQfvIuJVLTst3in0e7uTKeuY+WL/zfKn0xVujOTp42bS/vUUokhK5P2BppLd9JXMOMHcgbjA==",
             "dev": true
         },
         "@types/rimraf": {
             "version": "2.0.2",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@types/rimraf/-/rimraf-2.0.2.tgz",
-            "integrity": "sha1-fw/Dzw/wrSqZu3I64XZPMKyvi24=",
+            "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-2.0.2.tgz",
+            "integrity": "sha512-Hm/bnWq0TCy7jmjeN5bKYij9vw5GrDFWME4IuxV08278NtU/VdGbzsBohcCUJ7+QMqmUq5hpRKB39HeQWJjztQ==",
             "dev": true,
             "requires": {
                 "@types/glob": "*",
@@ -201,8 +201,8 @@
         },
         "@types/thrift": {
             "version": "0.10.7",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/@types/thrift/-/thrift-0.10.7.tgz",
-            "integrity": "sha1-qAwDJIL6juGLiF2/Q91PldG3MIo=",
+            "resolved": "https://registry.npmjs.org/@types/thrift/-/thrift-0.10.7.tgz",
+            "integrity": "sha512-Qh4Bmpn70JJX6Br8Q1VlGsoMnxPjU/CpoPZDccaHRLElEtx3WO5KwEnt4MawO8f+wwHi7DBqM605Ydlkym/45Q==",
             "dev": true,
             "requires": {
                 "@types/node": "*",
@@ -212,14 +212,14 @@
         },
         "ansi-regex": {
             "version": "2.1.1",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
             "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
             "dev": true
         },
         "ansi-styles": {
             "version": "3.2.1",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/ansi-styles/-/ansi-styles-3.2.1.tgz",
-            "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
             "dev": true,
             "requires": {
                 "color-convert": "^1.9.0"
@@ -227,8 +227,8 @@
         },
         "argparse": {
             "version": "1.0.10",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
             "requires": {
                 "sprintf-js": "~1.0.2"
@@ -236,19 +236,19 @@
         },
         "assertion-error": {
             "version": "1.1.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/assertion-error/-/assertion-error-1.1.0.tgz",
-            "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs=",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+            "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
             "dev": true
         },
         "async-limiter": {
             "version": "1.0.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/async-limiter/-/async-limiter-1.0.0.tgz",
-            "integrity": "sha1-ePrtjD0HSrgfIrTphdeehzj3IPg=",
+            "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+            "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
             "dev": true
         },
         "babel-code-frame": {
             "version": "6.26.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+            "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
             "requires": {
@@ -259,13 +259,13 @@
             "dependencies": {
                 "ansi-styles": {
                     "version": "2.2.1",
-                    "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                     "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
                     "dev": true
                 },
                 "chalk": {
                     "version": "1.1.3",
-                    "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/chalk/-/chalk-1.1.3.tgz",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
@@ -278,13 +278,13 @@
                 },
                 "js-tokens": {
                     "version": "3.0.2",
-                    "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/js-tokens/-/js-tokens-3.0.2.tgz",
+                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
                     "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
                     "dev": true
                 },
                 "supports-color": {
                     "version": "2.0.0",
-                    "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/supports-color/-/supports-color-2.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                     "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
                     "dev": true
                 }
@@ -292,13 +292,13 @@
         },
         "balanced-match": {
             "version": "1.0.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/balanced-match/-/balanced-match-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
             "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
             "version": "1.1.11",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -306,26 +306,26 @@
         },
         "browser-stdout": {
             "version": "1.3.1",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/browser-stdout/-/browser-stdout-1.3.1.tgz",
-            "integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA=",
+            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
             "dev": true
         },
         "buffer-from": {
             "version": "1.1.1",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/buffer-from/-/buffer-from-1.1.1.tgz",
-            "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
             "dev": true
         },
         "builtin-modules": {
             "version": "1.1.1",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/builtin-modules/-/builtin-modules-1.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
             "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
             "dev": true
         },
         "chai": {
             "version": "4.2.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/chai/-/chai-4.2.0.tgz",
-            "integrity": "sha1-dgqnLPION5XoSxKHfODoNzeqKeU=",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+            "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
             "dev": true,
             "requires": {
                 "assertion-error": "^1.1.0",
@@ -338,8 +338,8 @@
         },
         "chalk": {
             "version": "2.4.2",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/chalk/-/chalk-2.4.2.tgz",
-            "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
             "dev": true,
             "requires": {
                 "ansi-styles": "^3.2.1",
@@ -349,14 +349,14 @@
         },
         "check-error": {
             "version": "1.0.2",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/check-error/-/check-error-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
             "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
             "dev": true
         },
         "color-convert": {
             "version": "1.9.3",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/color-convert/-/color-convert-1.9.3.tgz",
-            "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
             "dev": true,
             "requires": {
                 "color-name": "1.1.3"
@@ -364,25 +364,25 @@
         },
         "color-name": {
             "version": "1.1.3",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/color-name/-/color-name-1.1.3.tgz",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
             "dev": true
         },
         "commander": {
             "version": "2.15.1",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/commander/-/commander-2.15.1.tgz",
-            "integrity": "sha1-30boZ9D8Kuxmo0ZitAapzK//Ww8=",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+            "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
             "dev": true
         },
         "concat-map": {
             "version": "0.0.1",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/concat-map/-/concat-map-0.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "debug": {
             "version": "3.1.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/debug/-/debug-3.1.0.tgz",
-            "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
             "dev": true,
             "requires": {
                 "ms": "2.0.0"
@@ -390,8 +390,8 @@
         },
         "deep-eql": {
             "version": "3.0.1",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/deep-eql/-/deep-eql-3.0.1.tgz",
-            "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+            "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
             "dev": true,
             "requires": {
                 "type-detect": "^4.0.0"
@@ -399,20 +399,20 @@
         },
         "diff": {
             "version": "3.5.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/diff/-/diff-3.5.0.tgz",
-            "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI=",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
             "dev": true
         },
         "escape-string-regexp": {
             "version": "1.0.5",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
             "dev": true
         },
         "eslint-plugin-prettier": {
             "version": "2.7.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/eslint-plugin-prettier/-/eslint-plugin-prettier-2.7.0.tgz",
-            "integrity": "sha1-tDEtzywdllN51/nVtfiqrcakWQQ=",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.7.0.tgz",
+            "integrity": "sha512-CStQYJgALoQBw3FsBzH0VOVDRnJ/ZimUlpLm226U8qgqYJfPOY/CPK6wyRInMxh73HSKg5wyRwdS4BVYYHwokA==",
             "dev": true,
             "requires": {
                 "fast-diff": "^1.1.1",
@@ -421,37 +421,37 @@
         },
         "esprima": {
             "version": "4.0.1",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
             "dev": true
         },
         "esutils": {
             "version": "2.0.2",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/esutils/-/esutils-2.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
             "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
             "dev": true
         },
         "fast-diff": {
             "version": "1.2.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/fast-diff/-/fast-diff-1.2.0.tgz",
-            "integrity": "sha1-c+4RmC2Gyq95WYKNUZz+kn+sXwM=",
+            "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+            "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
             "dev": true
         },
         "fs.realpath": {
             "version": "1.0.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "get-func-name": {
             "version": "2.0.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/get-func-name/-/get-func-name-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
             "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
             "dev": true
         },
         "glob": {
             "version": "7.1.3",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/glob/-/glob-7.1.3.tgz",
-            "integrity": "sha1-OWCDLT8VdBCDQtr9OmezMsCWnfE=",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+            "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
             "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -463,19 +463,19 @@
         },
         "globals": {
             "version": "11.10.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/globals/-/globals-11.10.0.tgz",
-            "integrity": "sha1-Hgl3bf/aXgGBazu0B3yLWcJOqlA=",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.10.0.tgz",
+            "integrity": "sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==",
             "dev": true
         },
         "growl": {
             "version": "1.10.5",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/growl/-/growl-1.10.5.tgz",
-            "integrity": "sha1-8nNdwig2dPpnR4sQGBBZNVw2nl4=",
+            "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+            "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
             "dev": true
         },
         "has-ansi": {
             "version": "2.0.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/has-ansi/-/has-ansi-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
@@ -484,19 +484,19 @@
         },
         "has-flag": {
             "version": "3.0.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/has-flag/-/has-flag-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
             "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
             "dev": true
         },
         "he": {
             "version": "1.1.1",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/he/-/he-1.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
             "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
             "dev": true
         },
         "inflight": {
             "version": "1.0.6",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/inflight/-/inflight-1.0.6.tgz",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "requires": {
                 "once": "^1.3.0",
@@ -505,19 +505,19 @@
         },
         "inherits": {
             "version": "2.0.3",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/inherits/-/inherits-2.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "istanbul-lib-coverage": {
             "version": "2.0.1",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
-            "integrity": "sha1-Ku4OBzrYxfagsA4N+/UrRmdHLto=",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+            "integrity": "sha512-nPvSZsVlbG9aLhZYaC3Oi1gT/tpyo3Yt5fNyf6NmcKIayz4VV/txxJFFKAK/gU4dcNn8ehsanBbVHVl0+amOLA==",
             "dev": true
         },
         "istanbul-lib-instrument": {
             "version": "3.0.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/istanbul-lib-instrument/-/istanbul-lib-instrument-3.0.0.tgz",
-            "integrity": "sha1-tfBmsqFh91eIvhep1Vb0Cgzyr8k=",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.0.0.tgz",
+            "integrity": "sha512-eQY9vN9elYjdgN9Iv6NS/00bptm02EBBk70lRMaVjeA6QYocQgenVrSgC28TJurdnZa80AGO3ASdFN+w/njGiQ==",
             "dev": true,
             "requires": {
                 "@babel/generator": "^7.0.0",
@@ -531,20 +531,20 @@
         },
         "jest-docblock": {
             "version": "21.2.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/jest-docblock/-/jest-docblock-21.2.0.tgz",
-            "integrity": "sha1-UVKcOzDV/RWdpgwnzu3Blfr41BQ=",
+            "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
+            "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
             "dev": true
         },
         "js-tokens": {
             "version": "4.0.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/js-tokens/-/js-tokens-4.0.0.tgz",
-            "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
             "dev": true
         },
         "js-yaml": {
             "version": "3.12.1",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/js-yaml/-/js-yaml-3.12.1.tgz",
-            "integrity": "sha1-KVyGMqGKI+BUz1ydPOyv5ngWdgA=",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
+            "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
             "dev": true,
             "requires": {
                 "argparse": "^1.0.7",
@@ -553,39 +553,39 @@
         },
         "jsesc": {
             "version": "2.5.2",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/jsesc/-/jsesc-2.5.2.tgz",
-            "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
             "dev": true
         },
         "lines-and-columns": {
             "version": "1.1.6",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
             "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
             "dev": true
         },
         "lodash": {
             "version": "4.17.11",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/lodash/-/lodash-4.17.11.tgz",
-            "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40=",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
             "dev": true
         },
         "minimatch": {
             "version": "3.0.4",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/minimatch/-/minimatch-3.0.4.tgz",
-            "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "requires": {
                 "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
             "version": "0.0.8",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/minimist/-/minimist-0.0.8.tgz",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
             "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
             "dev": true
         },
         "mkdirp": {
             "version": "0.5.1",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/mkdirp/-/mkdirp-0.5.1.tgz",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
             "dev": true,
             "requires": {
@@ -594,8 +594,8 @@
         },
         "mocha": {
             "version": "5.2.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/mocha/-/mocha-5.2.0.tgz",
-            "integrity": "sha1-bYrlCPWRZ/lA8rWzxKYSrlDJCuY=",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+            "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
             "dev": true,
             "requires": {
                 "browser-stdout": "1.3.1",
@@ -613,8 +613,8 @@
             "dependencies": {
                 "glob": {
                     "version": "7.1.2",
-                    "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/glob/-/glob-7.1.2.tgz",
-                    "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                     "dev": true,
                     "requires": {
                         "fs.realpath": "^1.0.0",
@@ -629,20 +629,20 @@
         },
         "ms": {
             "version": "2.0.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/ms/-/ms-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
             "dev": true
         },
         "node-int64": {
             "version": "0.4.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/node-int64/-/node-int64-0.4.0.tgz",
+            "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
             "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
             "dev": true
         },
         "nyc": {
             "version": "13.1.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/nyc/-/nyc-13.1.0.tgz",
-            "integrity": "sha1-RjZlx/9rV5jjImJKXrRJpnjbkOM=",
+            "resolved": "https://registry.npmjs.org/nyc/-/nyc-13.1.0.tgz",
+            "integrity": "sha512-3GyY6TpQ58z9Frpv4GMExE1SV2tAgYqC7HSy2omEhNiCT3mhT9NyiOvIE8zkbuJVFzmvvNTnE4h/7/wQae7xLg==",
             "dev": true,
             "requires": {
                 "archy": "^1.0.0",
@@ -1780,7 +1780,7 @@
         },
         "once": {
             "version": "1.4.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/once/-/once-1.4.0.tgz",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "requires": {
                 "wrappy": "1"
@@ -1788,37 +1788,37 @@
         },
         "path-is-absolute": {
             "version": "1.0.1",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "path-parse": {
             "version": "1.0.6",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/path-parse/-/path-parse-1.0.6.tgz",
-            "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
             "dev": true
         },
         "pathval": {
             "version": "1.1.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/pathval/-/pathval-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
             "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
             "dev": true
         },
         "prettier": {
             "version": "1.16.1",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/prettier/-/prettier-1.16.1.tgz",
-            "integrity": "sha1-U0wsnXhT+IReXgeDhOcZc710CJ8=",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.1.tgz",
+            "integrity": "sha512-XXUITwIkGb3CPJ2hforHah/zTINRyie5006Jd2HKy2qz7snEJXl0KLfsJZW/wst9g6R2rFvqba3VpNYdu1hDcA==",
             "dev": true
         },
         "q": {
             "version": "1.5.1",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/q/-/q-1.5.1.tgz",
+            "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
             "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
             "dev": true
         },
         "resolve": {
             "version": "1.10.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/resolve/-/resolve-1.10.0.tgz",
-            "integrity": "sha1-O9qur0XMB/N1ZW39LlTtCBCxAbo=",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+            "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
             "dev": true,
             "requires": {
                 "path-parse": "^1.0.6"
@@ -1826,8 +1826,8 @@
         },
         "rimraf": {
             "version": "2.6.3",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/rimraf/-/rimraf-2.6.3.tgz",
-            "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+            "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
             "dev": true,
             "requires": {
                 "glob": "^7.1.3"
@@ -1835,20 +1835,20 @@
         },
         "semver": {
             "version": "5.6.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/semver/-/semver-5.6.0.tgz",
-            "integrity": "sha1-fnQlb7qknHWqfHogXMInmcrIAAQ=",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+            "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
             "dev": true
         },
         "source-map": {
             "version": "0.5.7",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/source-map/-/source-map-0.5.7.tgz",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
             "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
             "dev": true
         },
         "source-map-support": {
             "version": "0.5.10",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/source-map-support/-/source-map-support-0.5.10.tgz",
-            "integrity": "sha1-IhQIC8nVGDJRHuK6uW48L5NTEgw=",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
+            "integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
             "dev": true,
             "requires": {
                 "buffer-from": "^1.0.0",
@@ -1857,21 +1857,21 @@
             "dependencies": {
                 "source-map": {
                     "version": "0.6.1",
-                    "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
                     "dev": true
                 }
             }
         },
         "sprintf-js": {
             "version": "1.0.3",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
         },
         "strip-ansi": {
             "version": "3.0.1",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
@@ -1880,8 +1880,8 @@
         },
         "supports-color": {
             "version": "5.4.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/supports-color/-/supports-color-5.4.0.tgz",
-            "integrity": "sha1-HGszdALCE3YF7+GfEP7DkPb6q1Q=",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+            "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
             "dev": true,
             "requires": {
                 "has-flag": "^3.0.0"
@@ -1889,7 +1889,7 @@
         },
         "thrift": {
             "version": "0.11.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/thrift/-/thrift-0.11.0.tgz",
+            "resolved": "https://registry.npmjs.org/thrift/-/thrift-0.11.0.tgz",
             "integrity": "sha1-JWEV5P+Hhx4SU39LUQvStCXhOZA=",
             "dev": true,
             "requires": {
@@ -1900,26 +1900,26 @@
         },
         "to-fast-properties": {
             "version": "2.0.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
             "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
             "dev": true
         },
         "trim-right": {
             "version": "1.0.1",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/trim-right/-/trim-right-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
             "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
             "dev": true
         },
         "tslib": {
             "version": "1.9.3",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/tslib/-/tslib-1.9.3.tgz",
-            "integrity": "sha1-1+TdeSRdhUKMTX5IIqeZF5VMooY=",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+            "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
             "dev": true
         },
         "tslint": {
             "version": "5.12.1",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/tslint/-/tslint-5.12.1.tgz",
-            "integrity": "sha1-jOydRUz4od6bCibXvbrW3jYuUsE=",
+            "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.12.1.tgz",
+            "integrity": "sha512-sfodBHOucFg6egff8d1BvuofoOQ/nOeYNfbp7LDlKBcLNrL3lmS5zoiDGyOMdT7YsEXAwWpTdAHwOGOc8eRZAw==",
             "dev": true,
             "requires": {
                 "babel-code-frame": "^6.22.0",
@@ -1938,14 +1938,14 @@
         },
         "tslint-config-prettier": {
             "version": "1.17.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/tslint-config-prettier/-/tslint-config-prettier-1.17.0.tgz",
-            "integrity": "sha1-lG7WEX+Y82WaZYSCeRVth2KMM9w=",
+            "resolved": "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.17.0.tgz",
+            "integrity": "sha512-NKWNkThwqE4Snn4Cm6SZB7lV5RMDDFsBwz6fWUkTxOKGjMx8ycOHnjIbhn7dZd5XmssW3CwqUjlANR6EhP9YQw==",
             "dev": true
         },
         "tslint-plugin-prettier": {
             "version": "2.0.1",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/tslint-plugin-prettier/-/tslint-plugin-prettier-2.0.1.tgz",
-            "integrity": "sha1-lbajt2ZiL/xEN1gl13YCJcUMNoA=",
+            "resolved": "https://registry.npmjs.org/tslint-plugin-prettier/-/tslint-plugin-prettier-2.0.1.tgz",
+            "integrity": "sha512-4FX9JIx/1rKHIPJNfMb+ooX1gPk5Vg3vNi7+dyFYpLO+O57F4g+b/fo1+W/G0SUOkBLHB/YKScxjX/P+7ZT/Tw==",
             "dev": true,
             "requires": {
                 "eslint-plugin-prettier": "^2.2.0",
@@ -1955,8 +1955,8 @@
         },
         "tsutils": {
             "version": "2.29.0",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/tsutils/-/tsutils-2.29.0.tgz",
-            "integrity": "sha1-MrSIUBRnrL7dS4VJhnOggSrKC5k=",
+            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+            "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
             "dev": true,
             "requires": {
                 "tslib": "^1.8.1"
@@ -1964,24 +1964,24 @@
         },
         "type-detect": {
             "version": "4.0.8",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/type-detect/-/type-detect-4.0.8.tgz",
-            "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
             "dev": true
         },
         "typescript": {
             "version": "3.2.4",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/typescript/-/typescript-3.2.4.tgz",
-            "integrity": "sha1-xYXLlSkSJj2RW0YnJs4kS6UQ7z0="
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+            "integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg=="
         },
         "wrappy": {
             "version": "1.0.2",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/wrappy/-/wrappy-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "ws": {
             "version": "6.1.3",
-            "resolved": "https://artifactory.corp.creditkarma.com:8443/artifactory/api/npm/npmjs/ws/-/ws-6.1.3.tgz",
-            "integrity": "sha1-0tLl8OPHAO8t6JCA68Csbhvzpy0=",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.3.tgz",
+            "integrity": "sha512-tbSxiT+qJI223AP4iLfQbkbxkwdFcneYinM2+x46Gx2wgvbaOMO36czfdfVUBRTHvzAMRhDd98sA5d/BuWbQdg==",
             "dev": true,
             "requires": {
                 "async-limiter": "~1.0.0"

--- a/src/main/render/shared/includes.ts
+++ b/src/main/render/shared/includes.ts
@@ -47,7 +47,17 @@ function statementUsesInt64(statement: ThriftStatement): boolean {
     switch (statement.type) {
         case SyntaxType.ServiceDefinition:
             return statement.functions.some((func: FunctionDefinition) => {
-                return func.returnType.type === SyntaxType.I64Keyword
+                if (func.returnType.type === SyntaxType.I64Keyword) {
+                    return true
+                }
+
+                for (const field of func.fields) {
+                    if (field.fieldType.type === SyntaxType.I64Keyword) {
+                        return true
+                    }
+                }
+
+                return false
             })
 
         case SyntaxType.StructDefinition:

--- a/src/tests/integration/thrift/user.thrift
+++ b/src/tests/integration/thrift/user.thrift
@@ -1,0 +1,10 @@
+namespace java user
+namespace js user
+
+struct User {
+  1: string name
+}
+
+service UserService {
+    User getUser(1: i64 id)
+}


### PR DESCRIPTION
Resolves #140 

If `i64` only appeared as a function argument in a Thrift file the generated TypeScript didn't include the import for `Int64`. This adds a check for the `i64` type in function arguments.