### PR TITLE
Fix encoding set and maps for unions in thrift-server

### DIFF
--- a/src/main/render/thrift-server/union/encode.ts
+++ b/src/main/render/thrift-server/union/encode.ts
@@ -262,7 +262,7 @@ function forEach(
     const forEachParameters: Array<ts.ParameterDeclaration> = [
         createFunctionParameter(
             value,
-            typeNodeForFieldType(fieldType.valueType, file),
+            typeNodeForFieldType(fieldType.valueType, file, true),
         ),
     ]
 
@@ -276,7 +276,7 @@ function forEach(
         forEachParameters.push(
             createFunctionParameter(
                 key,
-                typeNodeForFieldType(fieldType.keyType, file),
+                typeNodeForFieldType(fieldType.keyType, file, true),
             ),
         )
 

--- a/src/tests/unit/fixtures/apache/generated-multi-file/shared/SharedUnion.ts
+++ b/src/tests/unit/fixtures/apache/generated-multi-file/shared/SharedUnion.ts
@@ -9,10 +9,12 @@ import * as __NAMESPACE__ from "./.";
 export interface ISharedUnionArgs {
     option1?: string;
     option2?: string;
+    option3?: Set<Int64>;
 }
 export class SharedUnion {
     public option1?: string;
     public option2?: string;
+    public option3?: Set<Int64>;
     constructor(args?: ISharedUnionArgs) {
         let _fieldsSet: number = 0;
         if (args != null) {
@@ -23,6 +25,10 @@ export class SharedUnion {
             if (args.option2 != null) {
                 _fieldsSet++;
                 this.option2 = args.option2;
+            }
+            if (args.option3 != null) {
+                _fieldsSet++;
+                this.option3 = args.option3;
             }
             if (_fieldsSet > 1) {
                 throw new thrift.Thrift.TProtocolException(thrift.Thrift.TProtocolExceptionType.INVALID_DATA, "Cannot read a TUnion with more than one set value!");
@@ -38,6 +44,9 @@ export class SharedUnion {
     public static fromOption2(option2: string): SharedUnion {
         return new SharedUnion({ option2 });
     }
+    public static fromOption3(option3: Set<Int64>): SharedUnion {
+        return new SharedUnion({ option3 });
+    }
     public write(output: thrift.TProtocol): void {
         output.writeStructBegin("SharedUnion");
         if (this.option1 != null) {
@@ -48,6 +57,15 @@ export class SharedUnion {
         if (this.option2 != null) {
             output.writeFieldBegin("option2", thrift.Thrift.Type.STRING, 2);
             output.writeString(this.option2);
+            output.writeFieldEnd();
+        }
+        if (this.option3 != null) {
+            output.writeFieldBegin("option3", thrift.Thrift.Type.SET, 3);
+            output.writeSetBegin(thrift.Thrift.Type.I64, this.option3.size);
+            this.option3.forEach((value_1: Int64): void => {
+                output.writeI64(value_1);
+            });
+            output.writeSetEnd();
             output.writeFieldEnd();
         }
         output.writeFieldStop();
@@ -69,8 +87,8 @@ export class SharedUnion {
                 case 1:
                     if (fieldType === thrift.Thrift.Type.STRING) {
                         _fieldsSet++;
-                        const value_1: string = input.readString();
-                        _returnValue = SharedUnion.fromOption1(value_1);
+                        const value_2: string = input.readString();
+                        _returnValue = SharedUnion.fromOption1(value_2);
                     }
                     else {
                         input.skip(fieldType);
@@ -79,8 +97,25 @@ export class SharedUnion {
                 case 2:
                     if (fieldType === thrift.Thrift.Type.STRING) {
                         _fieldsSet++;
-                        const value_2: string = input.readString();
-                        _returnValue = SharedUnion.fromOption2(value_2);
+                        const value_3: string = input.readString();
+                        _returnValue = SharedUnion.fromOption2(value_3);
+                    }
+                    else {
+                        input.skip(fieldType);
+                    }
+                    break;
+                case 3:
+                    if (fieldType === thrift.Thrift.Type.SET) {
+                        _fieldsSet++;
+                        const value_4: Set<Int64> = new Set<Int64>();
+                        const metadata_1: thrift.TSet = input.readSetBegin();
+                        const size_1: number = metadata_1.size;
+                        for (let i_1: number = 0; i_1 < size_1; i_1++) {
+                            const value_5: Int64 = input.readI64();
+                            value_4.add(value_5);
+                        }
+                        input.readSetEnd();
+                        _returnValue = SharedUnion.fromOption3(value_4);
                     }
                     else {
                         input.skip(fieldType);

--- a/src/tests/unit/fixtures/apache/generated/shared/index.ts
+++ b/src/tests/unit/fixtures/apache/generated/shared/index.ts
@@ -146,10 +146,12 @@ export class SharedStruct {
 export interface ISharedUnionArgs {
     option1?: string;
     option2?: string;
+    option3?: Set<Int64>;
 }
 export class SharedUnion {
     public option1?: string;
     public option2?: string;
+    public option3?: Set<Int64>;
     constructor(args?: ISharedUnionArgs) {
         let _fieldsSet: number = 0;
         if (args != null) {
@@ -160,6 +162,10 @@ export class SharedUnion {
             if (args.option2 != null) {
                 _fieldsSet++;
                 this.option2 = args.option2;
+            }
+            if (args.option3 != null) {
+                _fieldsSet++;
+                this.option3 = args.option3;
             }
             if (_fieldsSet > 1) {
                 throw new thrift.Thrift.TProtocolException(thrift.Thrift.TProtocolExceptionType.INVALID_DATA, "Cannot read a TUnion with more than one set value!");
@@ -175,6 +181,9 @@ export class SharedUnion {
     public static fromOption2(option2: string): SharedUnion {
         return new SharedUnion({ option2 });
     }
+    public static fromOption3(option3: Set<Int64>): SharedUnion {
+        return new SharedUnion({ option3 });
+    }
     public write(output: thrift.TProtocol): void {
         output.writeStructBegin("SharedUnion");
         if (this.option1 != null) {
@@ -185,6 +194,15 @@ export class SharedUnion {
         if (this.option2 != null) {
             output.writeFieldBegin("option2", thrift.Thrift.Type.STRING, 2);
             output.writeString(this.option2);
+            output.writeFieldEnd();
+        }
+        if (this.option3 != null) {
+            output.writeFieldBegin("option3", thrift.Thrift.Type.SET, 3);
+            output.writeSetBegin(thrift.Thrift.Type.I64, this.option3.size);
+            this.option3.forEach((value_4: Int64): void => {
+                output.writeI64(value_4);
+            });
+            output.writeSetEnd();
             output.writeFieldEnd();
         }
         output.writeFieldStop();
@@ -206,8 +224,8 @@ export class SharedUnion {
                 case 1:
                     if (fieldType === thrift.Thrift.Type.STRING) {
                         _fieldsSet++;
-                        const value_4: string = input.readString();
-                        _returnValue = SharedUnion.fromOption1(value_4);
+                        const value_5: string = input.readString();
+                        _returnValue = SharedUnion.fromOption1(value_5);
                     }
                     else {
                         input.skip(fieldType);
@@ -216,8 +234,25 @@ export class SharedUnion {
                 case 2:
                     if (fieldType === thrift.Thrift.Type.STRING) {
                         _fieldsSet++;
-                        const value_5: string = input.readString();
-                        _returnValue = SharedUnion.fromOption2(value_5);
+                        const value_6: string = input.readString();
+                        _returnValue = SharedUnion.fromOption2(value_6);
+                    }
+                    else {
+                        input.skip(fieldType);
+                    }
+                    break;
+                case 3:
+                    if (fieldType === thrift.Thrift.Type.SET) {
+                        _fieldsSet++;
+                        const value_7: Set<Int64> = new Set<Int64>();
+                        const metadata_1: thrift.TSet = input.readSetBegin();
+                        const size_1: number = metadata_1.size;
+                        for (let i_1: number = 0; i_1 < size_1; i_1++) {
+                            const value_8: Int64 = input.readI64();
+                            value_7.add(value_8);
+                        }
+                        input.readSetEnd();
+                        _returnValue = SharedUnion.fromOption3(value_7);
                     }
                     else {
                         input.skip(fieldType);
@@ -282,8 +317,8 @@ export namespace SharedService {
                 switch (fieldId) {
                     case 1:
                         if (fieldType === thrift.Thrift.Type.I32) {
-                            const value_6: number = input.readI32();
-                            _args.key = value_6;
+                            const value_9: number = input.readI32();
+                            _args.key = value_9;
                         }
                         else {
                             input.skip(fieldType);
@@ -341,8 +376,8 @@ export namespace SharedService {
                 switch (fieldId) {
                     case 1:
                         if (fieldType === thrift.Thrift.Type.I32) {
-                            const value_7: number = input.readI32();
-                            _args.index = value_7;
+                            const value_10: number = input.readI32();
+                            _args.index = value_10;
                         }
                         else {
                             input.skip(fieldType);
@@ -397,8 +432,8 @@ export namespace SharedService {
                 switch (fieldId) {
                     case 0:
                         if (fieldType === thrift.Thrift.Type.STRUCT) {
-                            const value_8: SharedStruct = SharedStruct.read(input);
-                            _args.success = value_8;
+                            const value_11: SharedStruct = SharedStruct.read(input);
+                            _args.success = value_11;
                         }
                         else {
                             input.skip(fieldType);
@@ -448,8 +483,8 @@ export namespace SharedService {
                 switch (fieldId) {
                     case 0:
                         if (fieldType === thrift.Thrift.Type.STRUCT) {
-                            const value_9: SharedUnion = SharedUnion.read(input);
-                            _args.success = value_9;
+                            const value_12: SharedUnion = SharedUnion.read(input);
+                            _args.success = value_12;
                         }
                         else {
                             input.skip(fieldType);

--- a/src/tests/unit/fixtures/thrift-server/generated-multi-file/shared/SharedUnion.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-multi-file/shared/SharedUnion.ts
@@ -8,17 +8,20 @@ import * as __NAMESPACE__ from "./.";
 export interface ISharedUnion {
     option1?: string;
     option2?: string;
+    option3?: Set<thrift.Int64>;
 }
 export interface ISharedUnionArgs {
     option1?: string;
     option2?: string;
+    option3?: Set<number | thrift.Int64>;
 }
 export const SharedUnionCodec: thrift.IStructCodec<ISharedUnionArgs, ISharedUnion> = {
     encode(args: ISharedUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
         const obj = {
             option1: args.option1,
-            option2: args.option2
+            option2: args.option2,
+            option3: args.option3
         };
         output.writeStructBegin("SharedUnion");
         if (obj.option1 != null) {
@@ -31,6 +34,16 @@ export const SharedUnionCodec: thrift.IStructCodec<ISharedUnionArgs, ISharedUnio
             _fieldsSet++;
             output.writeFieldBegin("option2", thrift.TType.STRING, 2);
             output.writeString(obj.option2);
+            output.writeFieldEnd();
+        }
+        if (obj.option3 != null) {
+            _fieldsSet++;
+            output.writeFieldBegin("option3", thrift.TType.SET, 3);
+            output.writeSetBegin(thrift.TType.I64, obj.option3.size);
+            obj.option3.forEach((value_1: number | thrift.Int64): void => {
+                output.writeI64(value_1);
+            });
+            output.writeSetEnd();
             output.writeFieldEnd();
         }
         output.writeFieldStop();
@@ -58,8 +71,8 @@ export const SharedUnionCodec: thrift.IStructCodec<ISharedUnionArgs, ISharedUnio
                 case 1:
                     if (fieldType === thrift.TType.STRING) {
                         _fieldsSet++;
-                        const value_1: string = input.readString();
-                        _returnValue = { option1: value_1 };
+                        const value_2: string = input.readString();
+                        _returnValue = { option1: value_2 };
                     }
                     else {
                         input.skip(fieldType);
@@ -68,8 +81,25 @@ export const SharedUnionCodec: thrift.IStructCodec<ISharedUnionArgs, ISharedUnio
                 case 2:
                     if (fieldType === thrift.TType.STRING) {
                         _fieldsSet++;
-                        const value_2: string = input.readString();
-                        _returnValue = { option2: value_2 };
+                        const value_3: string = input.readString();
+                        _returnValue = { option2: value_3 };
+                    }
+                    else {
+                        input.skip(fieldType);
+                    }
+                    break;
+                case 3:
+                    if (fieldType === thrift.TType.SET) {
+                        _fieldsSet++;
+                        const value_4: Set<thrift.Int64> = new Set<thrift.Int64>();
+                        const metadata_1: thrift.IThriftSet = input.readSetBegin();
+                        const size_1: number = metadata_1.size;
+                        for (let i_1: number = 0; i_1 < size_1; i_1++) {
+                            const value_5: thrift.Int64 = input.readI64();
+                            value_4.add(value_5);
+                        }
+                        input.readSetEnd();
+                        _returnValue = { option3: value_4 };
                     }
                     else {
                         input.skip(fieldType);
@@ -99,6 +129,7 @@ export const SharedUnionCodec: thrift.IStructCodec<ISharedUnionArgs, ISharedUnio
 export class SharedUnion extends thrift.StructLike implements ISharedUnion {
     public option1?: string;
     public option2?: string;
+    public option3?: Set<thrift.Int64>;
     public readonly _annotations: thrift.IThriftAnnotations = {};
     public readonly _fieldAnnotations: thrift.IFieldAnnotations = {};
     constructor(args: ISharedUnionArgs = {}) {
@@ -106,13 +137,22 @@ export class SharedUnion extends thrift.StructLike implements ISharedUnion {
         let _fieldsSet: number = 0;
         if (args.option1 != null) {
             _fieldsSet++;
-            const value_3: string = args.option1;
-            this.option1 = value_3;
+            const value_6: string = args.option1;
+            this.option1 = value_6;
         }
         if (args.option2 != null) {
             _fieldsSet++;
-            const value_4: string = args.option2;
-            this.option2 = value_4;
+            const value_7: string = args.option2;
+            this.option2 = value_7;
+        }
+        if (args.option3 != null) {
+            _fieldsSet++;
+            const value_8: Set<thrift.Int64> = new Set<thrift.Int64>();
+            args.option3.forEach((value_9: number | thrift.Int64): void => {
+                const value_10: thrift.Int64 = (typeof value_9 === "number" ? new thrift.Int64(value_9) : value_9);
+                value_8.add(value_10);
+            });
+            this.option3 = value_8;
         }
         if (_fieldsSet > 1) {
             throw new thrift.TProtocolException(thrift.TProtocolExceptionType.INVALID_DATA, "TUnion cannot have more than one value");

--- a/src/tests/unit/fixtures/thrift-server/generated/shared/index.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/shared/index.ts
@@ -196,17 +196,20 @@ export class SharedStruct extends thrift.StructLike implements ISharedStruct {
 export interface ISharedUnion {
     option1?: string;
     option2?: string;
+    option3?: Set<thrift.Int64>;
 }
 export interface ISharedUnionArgs {
     option1?: string;
     option2?: string;
+    option3?: Set<number | thrift.Int64>;
 }
 export const SharedUnionCodec: thrift.IStructCodec<ISharedUnionArgs, ISharedUnion> = {
     encode(args: ISharedUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
         const obj = {
             option1: args.option1,
-            option2: args.option2
+            option2: args.option2,
+            option3: args.option3
         };
         output.writeStructBegin("SharedUnion");
         if (obj.option1 != null) {
@@ -219,6 +222,16 @@ export const SharedUnionCodec: thrift.IStructCodec<ISharedUnionArgs, ISharedUnio
             _fieldsSet++;
             output.writeFieldBegin("option2", thrift.TType.STRING, 2);
             output.writeString(obj.option2);
+            output.writeFieldEnd();
+        }
+        if (obj.option3 != null) {
+            _fieldsSet++;
+            output.writeFieldBegin("option3", thrift.TType.SET, 3);
+            output.writeSetBegin(thrift.TType.I64, obj.option3.size);
+            obj.option3.forEach((value_7: number | thrift.Int64): void => {
+                output.writeI64(value_7);
+            });
+            output.writeSetEnd();
             output.writeFieldEnd();
         }
         output.writeFieldStop();
@@ -246,8 +259,8 @@ export const SharedUnionCodec: thrift.IStructCodec<ISharedUnionArgs, ISharedUnio
                 case 1:
                     if (fieldType === thrift.TType.STRING) {
                         _fieldsSet++;
-                        const value_7: string = input.readString();
-                        _returnValue = { option1: value_7 };
+                        const value_8: string = input.readString();
+                        _returnValue = { option1: value_8 };
                     }
                     else {
                         input.skip(fieldType);
@@ -256,8 +269,25 @@ export const SharedUnionCodec: thrift.IStructCodec<ISharedUnionArgs, ISharedUnio
                 case 2:
                     if (fieldType === thrift.TType.STRING) {
                         _fieldsSet++;
-                        const value_8: string = input.readString();
-                        _returnValue = { option2: value_8 };
+                        const value_9: string = input.readString();
+                        _returnValue = { option2: value_9 };
+                    }
+                    else {
+                        input.skip(fieldType);
+                    }
+                    break;
+                case 3:
+                    if (fieldType === thrift.TType.SET) {
+                        _fieldsSet++;
+                        const value_10: Set<thrift.Int64> = new Set<thrift.Int64>();
+                        const metadata_1: thrift.IThriftSet = input.readSetBegin();
+                        const size_1: number = metadata_1.size;
+                        for (let i_1: number = 0; i_1 < size_1; i_1++) {
+                            const value_11: thrift.Int64 = input.readI64();
+                            value_10.add(value_11);
+                        }
+                        input.readSetEnd();
+                        _returnValue = { option3: value_10 };
                     }
                     else {
                         input.skip(fieldType);
@@ -287,6 +317,7 @@ export const SharedUnionCodec: thrift.IStructCodec<ISharedUnionArgs, ISharedUnio
 export class SharedUnion extends thrift.StructLike implements ISharedUnion {
     public option1?: string;
     public option2?: string;
+    public option3?: Set<thrift.Int64>;
     public readonly _annotations: thrift.IThriftAnnotations = {};
     public readonly _fieldAnnotations: thrift.IFieldAnnotations = {};
     constructor(args: ISharedUnionArgs = {}) {
@@ -294,13 +325,22 @@ export class SharedUnion extends thrift.StructLike implements ISharedUnion {
         let _fieldsSet: number = 0;
         if (args.option1 != null) {
             _fieldsSet++;
-            const value_9: string = args.option1;
-            this.option1 = value_9;
+            const value_12: string = args.option1;
+            this.option1 = value_12;
         }
         if (args.option2 != null) {
             _fieldsSet++;
-            const value_10: string = args.option2;
-            this.option2 = value_10;
+            const value_13: string = args.option2;
+            this.option2 = value_13;
+        }
+        if (args.option3 != null) {
+            _fieldsSet++;
+            const value_14: Set<thrift.Int64> = new Set<thrift.Int64>();
+            args.option3.forEach((value_15: number | thrift.Int64): void => {
+                const value_16: thrift.Int64 = (typeof value_15 === "number" ? new thrift.Int64(value_15) : value_15);
+                value_14.add(value_16);
+            });
+            this.option3 = value_14;
         }
         if (_fieldsSet > 1) {
             throw new thrift.TProtocolException(thrift.TProtocolExceptionType.INVALID_DATA, "TUnion cannot have more than one value");
@@ -370,8 +410,8 @@ export namespace SharedService {
                 switch (fieldId) {
                     case 1:
                         if (fieldType === thrift.TType.I32) {
-                            const value_11: number = input.readI32();
-                            _args.key = value_11;
+                            const value_17: number = input.readI32();
+                            _args.key = value_17;
                         }
                         else {
                             input.skip(fieldType);
@@ -401,8 +441,8 @@ export namespace SharedService {
         constructor(args: IGetStruct__ArgsArgs) {
             super();
             if (args.key != null) {
-                const value_12: number = args.key;
-                this.key = value_12;
+                const value_18: number = args.key;
+                this.key = value_18;
             }
             else {
                 throw new thrift.TProtocolException(thrift.TProtocolExceptionType.UNKNOWN, "Required field[key] is unset!");
@@ -455,8 +495,8 @@ export namespace SharedService {
                 switch (fieldId) {
                     case 1:
                         if (fieldType === thrift.TType.I32) {
-                            const value_13: number = input.readI32();
-                            _args.index = value_13;
+                            const value_19: number = input.readI32();
+                            _args.index = value_19;
                         }
                         else {
                             input.skip(fieldType);
@@ -486,8 +526,8 @@ export namespace SharedService {
         constructor(args: IGetUnion__ArgsArgs) {
             super();
             if (args.index != null) {
-                const value_14: number = args.index;
-                this.index = value_14;
+                const value_20: number = args.index;
+                this.index = value_20;
             }
             else {
                 throw new thrift.TProtocolException(thrift.TProtocolExceptionType.UNKNOWN, "Required field[index] is unset!");
@@ -537,8 +577,8 @@ export namespace SharedService {
                 switch (fieldId) {
                     case 0:
                         if (fieldType === thrift.TType.STRUCT) {
-                            const value_15: ISharedStruct = SharedStructCodec.decode(input);
-                            _args.success = value_15;
+                            const value_21: ISharedStruct = SharedStructCodec.decode(input);
+                            _args.success = value_21;
                         }
                         else {
                             input.skip(fieldType);
@@ -563,8 +603,8 @@ export namespace SharedService {
         constructor(args: IGetStruct__ResultArgs = {}) {
             super();
             if (args.success != null) {
-                const value_16: ISharedStruct = new SharedStruct(args.success);
-                this.success = value_16;
+                const value_22: ISharedStruct = new SharedStruct(args.success);
+                this.success = value_22;
             }
         }
         public static read(input: thrift.TProtocol): GetStruct__Result {
@@ -611,8 +651,8 @@ export namespace SharedService {
                 switch (fieldId) {
                     case 0:
                         if (fieldType === thrift.TType.STRUCT) {
-                            const value_17: ISharedUnion = SharedUnionCodec.decode(input);
-                            _args.success = value_17;
+                            const value_23: ISharedUnion = SharedUnionCodec.decode(input);
+                            _args.success = value_23;
                         }
                         else {
                             input.skip(fieldType);
@@ -637,8 +677,8 @@ export namespace SharedService {
         constructor(args: IGetUnion__ResultArgs = {}) {
             super();
             if (args.success != null) {
-                const value_18: ISharedUnion = new SharedUnion(args.success);
-                this.success = value_18;
+                const value_24: ISharedUnion = new SharedUnion(args.success);
+                this.success = value_24;
             }
         }
         public static read(input: thrift.TProtocol): GetUnion__Result {

--- a/src/tests/unit/fixtures/thrift/shared.thrift
+++ b/src/tests/unit/fixtures/thrift/shared.thrift
@@ -21,6 +21,7 @@ struct SharedStruct {
 union SharedUnion {
   1: string option1
   2: string option2
+  3: set<i64> option3
 }
 
 service SharedService {

--- a/src/tests/unit/index.spec.ts
+++ b/src/tests/unit/index.spec.ts
@@ -18,9 +18,7 @@ function readSolution(name: string, target: CompileTarget = 'apache'): string {
 function readDir(dir: string): FileList {
     return fs
         .readdirSync(dir)
-        .filter((file) => {
-            file.endsWith('.ts')
-        })
+        .filter((file) => file.endsWith('.ts'))
         .map((name) => ({
             name,
             content: fs.readFileSync(path.join(dir, name), 'utf-8'),


### PR DESCRIPTION
Currently the encode method for thrift unions uses the wrong type when mapping values for lists, sets, and maps (it should be using the loose variant for the type).  This results in invalid typescript when in strict mode. 

This only changes the codegen for thrift-typescript. 