### PR TITLE
feat: Allow i64 to be represented as string in user code

### DIFF
--- a/src/main/render/apache/types.ts
+++ b/src/main/render/apache/types.ts
@@ -233,18 +233,18 @@ export function typeNodeForFieldType(
             return ts.createTypeReferenceNode(fieldType.value, undefined)
 
         case SyntaxType.SetType:
-            return ts.createTypeReferenceNode('Set', [
+            return ts.createTypeReferenceNode(COMMON_IDENTIFIERS.Set, [
                 typeNodeForFieldType(fieldType.valueType),
             ])
 
         case SyntaxType.MapType:
-            return ts.createTypeReferenceNode('Map', [
+            return ts.createTypeReferenceNode(COMMON_IDENTIFIERS.Map, [
                 typeNodeForFieldType(fieldType.keyType),
                 typeNodeForFieldType(fieldType.valueType),
             ])
 
         case SyntaxType.ListType:
-            return ts.createTypeReferenceNode('Array', [
+            return ts.createTypeReferenceNode(COMMON_IDENTIFIERS.Array, [
                 typeNodeForFieldType(fieldType.valueType),
             ])
 

--- a/src/main/render/thrift-server/types.ts
+++ b/src/main/render/thrift-server/types.ts
@@ -275,18 +275,18 @@ export function typeNodeForFieldType(
             )
 
         case SyntaxType.SetType:
-            return ts.createTypeReferenceNode('Set', [
+            return ts.createTypeReferenceNode(COMMON_IDENTIFIERS.Set, [
                 typeNodeForFieldType(fieldType.valueType, state, loose),
             ])
 
         case SyntaxType.MapType:
-            return ts.createTypeReferenceNode('Map', [
+            return ts.createTypeReferenceNode(COMMON_IDENTIFIERS.Map, [
                 typeNodeForFieldType(fieldType.keyType, state, loose),
                 typeNodeForFieldType(fieldType.valueType, state, loose),
             ])
 
         case SyntaxType.ListType:
-            return ts.createTypeReferenceNode('Array', [
+            return ts.createTypeReferenceNode(COMMON_IDENTIFIERS.Array, [
                 typeNodeForFieldType(fieldType.valueType, state, loose),
             ])
 
@@ -300,6 +300,7 @@ export function typeNodeForFieldType(
             if (loose === true) {
                 return ts.createUnionTypeNode([
                     createNumberType(),
+                    createStringType(),
                     ts.createTypeReferenceNode(
                         COMMON_IDENTIFIERS.Int64,
                         undefined,

--- a/src/main/render/thrift-server/utils.ts
+++ b/src/main/render/thrift-server/utils.ts
@@ -43,7 +43,22 @@ export function coerceType(
                     ts.createNew(COMMON_IDENTIFIERS.Int64, undefined, [
                         valueName,
                     ]),
-                    valueName,
+                    ts.createConditional(
+                        ts.createBinary(
+                            ts.createTypeOf(valueName),
+                            ts.SyntaxKind.EqualsEqualsEqualsToken,
+                            ts.createLiteral('string'),
+                        ),
+                        ts.createCall(
+                            ts.createPropertyAccess(
+                                COMMON_IDENTIFIERS.Int64,
+                                ts.createIdentifier('fromDecimalString'),
+                            ),
+                            undefined,
+                            [valueName],
+                        ),
+                        valueName,
+                    ),
                 ),
             )
 

--- a/src/tests/unit/fixtures/generated/calculator/index.ts
+++ b/src/tests/unit/fixtures/generated/calculator/index.ts
@@ -685,14 +685,14 @@ export namespace Calculator {
         num2: thrift.Int64;
     }
     export interface IAddInt64__ArgsArgs {
-        num1: number | thrift.Int64;
-        num2: number | thrift.Int64;
+        num1: number | string | thrift.Int64;
+        num2: number | string | thrift.Int64;
     }
     export const AddInt64__ArgsCodec: thrift.IStructCodec<IAddInt64__ArgsArgs, IAddInt64__Args> = {
         encode(args: IAddInt64__ArgsArgs, output: thrift.TProtocol): void {
             const obj = {
-                num1: (typeof args.num1 === "number" ? new thrift.Int64(args.num1) : args.num1),
-                num2: (typeof args.num2 === "number" ? new thrift.Int64(args.num2) : args.num2)
+                num1: (typeof args.num1 === "number" ? new thrift.Int64(args.num1) : typeof args.num1 === "string" ? thrift.Int64.fromDecimalString(args.num1) : args.num1),
+                num2: (typeof args.num2 === "number" ? new thrift.Int64(args.num2) : typeof args.num2 === "string" ? thrift.Int64.fromDecimalString(args.num2) : args.num2)
             };
             output.writeStructBegin("AddInt64__Args");
             if (obj.num1 != null) {
@@ -770,14 +770,14 @@ export namespace Calculator {
         constructor(args: IAddInt64__ArgsArgs) {
             super();
             if (args.num1 != null) {
-                const value_23: thrift.Int64 = (typeof args.num1 === "number" ? new thrift.Int64(args.num1) : args.num1);
+                const value_23: thrift.Int64 = (typeof args.num1 === "number" ? new thrift.Int64(args.num1) : typeof args.num1 === "string" ? thrift.Int64.fromDecimalString(args.num1) : args.num1);
                 this.num1 = value_23;
             }
             else {
                 throw new thrift.TProtocolException(thrift.TProtocolExceptionType.UNKNOWN, "Required field[num1] is unset!");
             }
             if (args.num2 != null) {
-                const value_24: thrift.Int64 = (typeof args.num2 === "number" ? new thrift.Int64(args.num2) : args.num2);
+                const value_24: thrift.Int64 = (typeof args.num2 === "number" ? new thrift.Int64(args.num2) : typeof args.num2 === "string" ? thrift.Int64.fromDecimalString(args.num2) : args.num2);
                 this.num2 = value_24;
             }
             else {
@@ -1929,12 +1929,12 @@ export namespace Calculator {
         success?: thrift.Int64;
     }
     export interface IAddInt64__ResultArgs {
-        success?: number | thrift.Int64;
+        success?: number | string | thrift.Int64;
     }
     export const AddInt64__ResultCodec: thrift.IStructCodec<IAddInt64__ResultArgs, IAddInt64__Result> = {
         encode(args: IAddInt64__ResultArgs, output: thrift.TProtocol): void {
             const obj = {
-                success: (typeof args.success === "number" ? new thrift.Int64(args.success) : args.success)
+                success: (typeof args.success === "number" ? new thrift.Int64(args.success) : typeof args.success === "string" ? thrift.Int64.fromDecimalString(args.success) : args.success)
             };
             output.writeStructBegin("AddInt64__Result");
             if (obj.success != null) {
@@ -1985,7 +1985,7 @@ export namespace Calculator {
         constructor(args: IAddInt64__ResultArgs = {}) {
             super();
             if (args.success != null) {
-                const value_69: thrift.Int64 = (typeof args.success === "number" ? new thrift.Int64(args.success) : args.success);
+                const value_69: thrift.Int64 = (typeof args.success === "number" ? new thrift.Int64(args.success) : typeof args.success === "string" ? thrift.Int64.fromDecimalString(args.success) : args.success);
                 this.success = value_69;
             }
         }
@@ -2961,7 +2961,7 @@ export namespace Calculator {
                 }
             });
         }
-        public addInt64(num1: number | thrift.Int64, num2: number | thrift.Int64, context?: Context): Promise<thrift.Int64> {
+        public addInt64(num1: number | string | thrift.Int64, num2: number | string | thrift.Int64, context?: Context): Promise<thrift.Int64> {
             const writer: thrift.TTransport = new this.transport();
             const output: thrift.TProtocol = new this.protocol(writer);
             output.writeMessageBegin("addInt64", thrift.MessageType.CALL, this.incrementRequestId());
@@ -3419,7 +3419,7 @@ export namespace Calculator {
     export interface ILocalHandler<Context = any> {
         ping(context?: Context): void | Promise<void>;
         add(num1: number, num2: number, context?: Context): number | Promise<number>;
-        addInt64(num1: thrift.Int64, num2: thrift.Int64, context?: Context): (number | thrift.Int64) | Promise<number | thrift.Int64>;
+        addInt64(num1: thrift.Int64, num2: thrift.Int64, context?: Context): (number | string | thrift.Int64) | Promise<number | string | thrift.Int64>;
         addWithContext(num1: number, num2: number, context?: Context): number | Promise<number>;
         calculate(logid: number, work: IWork, context?: Context): number | Promise<number>;
         echoBinary(word: Buffer, context?: Context): string | Promise<string>;
@@ -3592,7 +3592,7 @@ export namespace Calculator {
             });
         }
         public process_addInt64(requestId: number, input: thrift.TProtocol, output: thrift.TProtocol, context: Context): Promise<Buffer> {
-            return new Promise<number | thrift.Int64>((resolve, reject): void => {
+            return new Promise<number | string | thrift.Int64>((resolve, reject): void => {
                 try {
                     const args: IAddInt64__Args = AddInt64__ArgsCodec.decode(input);
                     input.readMessageEnd();
@@ -3601,7 +3601,7 @@ export namespace Calculator {
                 catch (err) {
                     reject(err);
                 }
-            }).then((data: number | thrift.Int64): Buffer => {
+            }).then((data: number | string | thrift.Int64): Buffer => {
                 const result: IAddInt64__ResultArgs = { success: data };
                 output.writeMessageBegin("addInt64", thrift.MessageType.REPLY, requestId);
                 AddInt64__ResultCodec.encode(result, output);

--- a/src/tests/unit/fixtures/generated/shared/index.ts
+++ b/src/tests/unit/fixtures/generated/shared/index.ts
@@ -9,12 +9,12 @@ export interface ICode {
     status?: thrift.Int64;
 }
 export interface ICodeArgs {
-    status?: number | thrift.Int64;
+    status?: number | string | thrift.Int64;
 }
 export const CodeCodec: thrift.IStructCodec<ICodeArgs, ICode> = {
     encode(args: ICodeArgs, output: thrift.TProtocol): void {
         const obj = {
-            status: (typeof args.status === "number" ? new thrift.Int64(args.status) : args.status)
+            status: (typeof args.status === "number" ? new thrift.Int64(args.status) : typeof args.status === "string" ? thrift.Int64.fromDecimalString(args.status) : args.status)
         };
         output.writeStructBegin("Code");
         if (obj.status != null) {
@@ -65,7 +65,7 @@ export class Code extends thrift.StructLike implements ICode {
     constructor(args: ICodeArgs = {}) {
         super();
         if (args.status != null) {
-            const value_2: thrift.Int64 = (typeof args.status === "number" ? new thrift.Int64(args.status) : args.status);
+            const value_2: thrift.Int64 = (typeof args.status === "number" ? new thrift.Int64(args.status) : typeof args.status === "string" ? thrift.Int64.fromDecimalString(args.status) : args.status);
             this.status = value_2;
         }
     }

--- a/src/tests/unit/fixtures/generated/strict-unions/calculator/index.ts
+++ b/src/tests/unit/fixtures/generated/strict-unions/calculator/index.ts
@@ -714,14 +714,14 @@ export namespace Calculator {
         num2: thrift.Int64;
     }
     export interface IAddInt64__ArgsArgs {
-        num1: number | thrift.Int64;
-        num2: number | thrift.Int64;
+        num1: number | string | thrift.Int64;
+        num2: number | string | thrift.Int64;
     }
     export const AddInt64__ArgsCodec: thrift.IStructCodec<IAddInt64__ArgsArgs, IAddInt64__Args> = {
         encode(args: IAddInt64__ArgsArgs, output: thrift.TProtocol): void {
             const obj = {
-                num1: (typeof args.num1 === "number" ? new thrift.Int64(args.num1) : args.num1),
-                num2: (typeof args.num2 === "number" ? new thrift.Int64(args.num2) : args.num2)
+                num1: (typeof args.num1 === "number" ? new thrift.Int64(args.num1) : typeof args.num1 === "string" ? thrift.Int64.fromDecimalString(args.num1) : args.num1),
+                num2: (typeof args.num2 === "number" ? new thrift.Int64(args.num2) : typeof args.num2 === "string" ? thrift.Int64.fromDecimalString(args.num2) : args.num2)
             };
             output.writeStructBegin("AddInt64__Args");
             if (obj.num1 != null) {
@@ -799,14 +799,14 @@ export namespace Calculator {
         constructor(args: IAddInt64__ArgsArgs) {
             super();
             if (args.num1 != null) {
-                const value_23: thrift.Int64 = (typeof args.num1 === "number" ? new thrift.Int64(args.num1) : args.num1);
+                const value_23: thrift.Int64 = (typeof args.num1 === "number" ? new thrift.Int64(args.num1) : typeof args.num1 === "string" ? thrift.Int64.fromDecimalString(args.num1) : args.num1);
                 this.num1 = value_23;
             }
             else {
                 throw new thrift.TProtocolException(thrift.TProtocolExceptionType.UNKNOWN, "Required field[num1] is unset!");
             }
             if (args.num2 != null) {
-                const value_24: thrift.Int64 = (typeof args.num2 === "number" ? new thrift.Int64(args.num2) : args.num2);
+                const value_24: thrift.Int64 = (typeof args.num2 === "number" ? new thrift.Int64(args.num2) : typeof args.num2 === "string" ? thrift.Int64.fromDecimalString(args.num2) : args.num2);
                 this.num2 = value_24;
             }
             else {
@@ -1958,12 +1958,12 @@ export namespace Calculator {
         success?: thrift.Int64;
     }
     export interface IAddInt64__ResultArgs {
-        success?: number | thrift.Int64;
+        success?: number | string | thrift.Int64;
     }
     export const AddInt64__ResultCodec: thrift.IStructCodec<IAddInt64__ResultArgs, IAddInt64__Result> = {
         encode(args: IAddInt64__ResultArgs, output: thrift.TProtocol): void {
             const obj = {
-                success: (typeof args.success === "number" ? new thrift.Int64(args.success) : args.success)
+                success: (typeof args.success === "number" ? new thrift.Int64(args.success) : typeof args.success === "string" ? thrift.Int64.fromDecimalString(args.success) : args.success)
             };
             output.writeStructBegin("AddInt64__Result");
             if (obj.success != null) {
@@ -2014,7 +2014,7 @@ export namespace Calculator {
         constructor(args: IAddInt64__ResultArgs = {}) {
             super();
             if (args.success != null) {
-                const value_69: thrift.Int64 = (typeof args.success === "number" ? new thrift.Int64(args.success) : args.success);
+                const value_69: thrift.Int64 = (typeof args.success === "number" ? new thrift.Int64(args.success) : typeof args.success === "string" ? thrift.Int64.fromDecimalString(args.success) : args.success);
                 this.success = value_69;
             }
         }
@@ -2990,7 +2990,7 @@ export namespace Calculator {
                 }
             });
         }
-        public addInt64(num1: number | thrift.Int64, num2: number | thrift.Int64, context?: Context): Promise<thrift.Int64> {
+        public addInt64(num1: number | string | thrift.Int64, num2: number | string | thrift.Int64, context?: Context): Promise<thrift.Int64> {
             const writer: thrift.TTransport = new this.transport();
             const output: thrift.TProtocol = new this.protocol(writer);
             output.writeMessageBegin("addInt64", thrift.MessageType.CALL, this.incrementRequestId());
@@ -3448,7 +3448,7 @@ export namespace Calculator {
     export interface ILocalHandler<Context = any> {
         ping(context?: Context): void | Promise<void>;
         add(num1: number, num2: number, context?: Context): number | Promise<number>;
-        addInt64(num1: thrift.Int64, num2: thrift.Int64, context?: Context): (number | thrift.Int64) | Promise<number | thrift.Int64>;
+        addInt64(num1: thrift.Int64, num2: thrift.Int64, context?: Context): (number | string | thrift.Int64) | Promise<number | string | thrift.Int64>;
         addWithContext(num1: number, num2: number, context?: Context): number | Promise<number>;
         calculate(logid: number, work: IWork, context?: Context): number | Promise<number>;
         echoBinary(word: Buffer, context?: Context): string | Promise<string>;
@@ -3621,7 +3621,7 @@ export namespace Calculator {
             });
         }
         public process_addInt64(requestId: number, input: thrift.TProtocol, output: thrift.TProtocol, context: Context): Promise<Buffer> {
-            return new Promise<number | thrift.Int64>((resolve, reject): void => {
+            return new Promise<number | string | thrift.Int64>((resolve, reject): void => {
                 try {
                     const args: IAddInt64__Args = AddInt64__ArgsCodec.decode(input);
                     input.readMessageEnd();
@@ -3630,7 +3630,7 @@ export namespace Calculator {
                 catch (err) {
                     reject(err);
                 }
-            }).then((data: number | thrift.Int64): Buffer => {
+            }).then((data: number | string | thrift.Int64): Buffer => {
                 const result: IAddInt64__ResultArgs = { success: data };
                 output.writeMessageBegin("addInt64", thrift.MessageType.REPLY, requestId);
                 AddInt64__ResultCodec.encode(result, output);

--- a/src/tests/unit/fixtures/generated/strict-unions/shared/index.ts
+++ b/src/tests/unit/fixtures/generated/strict-unions/shared/index.ts
@@ -9,12 +9,12 @@ export interface ICode {
     status?: thrift.Int64;
 }
 export interface ICodeArgs {
-    status?: number | thrift.Int64;
+    status?: number | string | thrift.Int64;
 }
 export const CodeCodec: thrift.IStructCodec<ICodeArgs, ICode> = {
     encode(args: ICodeArgs, output: thrift.TProtocol): void {
         const obj = {
-            status: (typeof args.status === "number" ? new thrift.Int64(args.status) : args.status)
+            status: (typeof args.status === "number" ? new thrift.Int64(args.status) : typeof args.status === "string" ? thrift.Int64.fromDecimalString(args.status) : args.status)
         };
         output.writeStructBegin("Code");
         if (obj.status != null) {
@@ -65,7 +65,7 @@ export class Code extends thrift.StructLike implements ICode {
     constructor(args: ICodeArgs = {}) {
         super();
         if (args.status != null) {
-            const value_2: thrift.Int64 = (typeof args.status === "number" ? new thrift.Int64(args.status) : args.status);
+            const value_2: thrift.Int64 = (typeof args.status === "number" ? new thrift.Int64(args.status) : typeof args.status === "string" ? thrift.Int64.fromDecimalString(args.status) : args.status);
             this.status = value_2;
         }
     }

--- a/src/tests/unit/fixtures/thrift-server/annotations_struct.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/annotations_struct.solution.ts
@@ -4,13 +4,13 @@ export interface IMyStruct {
 }
 export interface IMyStructArgs {
     id?: number;
-    bigID?: number | thrift.Int64;
+    bigID?: number | string | thrift.Int64;
 }
 export const MyStructCodec: thrift.IStructCodec<IMyStructArgs, IMyStruct> = {
     encode(args: IMyStructArgs, output: thrift.TProtocol): void {
         const obj = {
             id: (args.id != null ? args.id : 45),
-            bigID: (args.bigID != null ? (typeof args.bigID === "number" ? new thrift.Int64(args.bigID) : args.bigID) : thrift.Int64.fromDecimalString("23948234"))
+            bigID: (args.bigID != null ? (typeof args.bigID === "number" ? new thrift.Int64(args.bigID) : typeof args.bigID === "string" ? thrift.Int64.fromDecimalString(args.bigID) : args.bigID) : thrift.Int64.fromDecimalString("23948234"))
         };
         output.writeStructBegin("MyStruct");
         if (obj.id != null) {
@@ -100,7 +100,7 @@ export class MyStruct extends thrift.StructLike implements IMyStruct {
             this.id = value_3;
         }
         if (args.bigID != null) {
-            const value_4: thrift.Int64 = (typeof args.bigID === "number" ? new thrift.Int64(args.bigID) : args.bigID);
+            const value_4: thrift.Int64 = (typeof args.bigID === "number" ? new thrift.Int64(args.bigID) : typeof args.bigID === "string" ? thrift.Int64.fromDecimalString(args.bigID) : args.bigID);
             this.bigID = value_4;
         }
     }

--- a/src/tests/unit/fixtures/thrift-server/annotations_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/annotations_union.solution.ts
@@ -4,14 +4,14 @@ export interface IMyUnion {
 }
 export interface IMyUnionArgs {
     field1?: number;
-    field2?: number | thrift.Int64;
+    field2?: number | string | thrift.Int64;
 }
 export const MyUnionCodec: thrift.IStructCodec<IMyUnionArgs, IMyUnion> = {
     encode(args: IMyUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
         const obj = {
             field1: args.field1,
-            field2: (typeof args.field2 === "number" ? new thrift.Int64(args.field2) : args.field2)
+            field2: (typeof args.field2 === "number" ? new thrift.Int64(args.field2) : typeof args.field2 === "string" ? thrift.Int64.fromDecimalString(args.field2) : args.field2)
         };
         output.writeStructBegin("MyUnion");
         if (obj.field1 != null) {
@@ -118,7 +118,7 @@ export class MyUnion extends thrift.StructLike implements IMyUnion {
         }
         if (args.field2 != null) {
             _fieldsSet++;
-            const value_4: thrift.Int64 = (typeof args.field2 === "number" ? new thrift.Int64(args.field2) : args.field2);
+            const value_4: thrift.Int64 = (typeof args.field2 === "number" ? new thrift.Int64(args.field2) : typeof args.field2 === "string" ? thrift.Int64.fromDecimalString(args.field2) : args.field2);
             this.field2 = value_4;
         }
         if (_fieldsSet > 1) {

--- a/src/tests/unit/fixtures/thrift-server/basic_service.strict_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/basic_service.strict_union.solution.ts
@@ -20,7 +20,7 @@ export interface IMyUnionWithField1Args {
 }
 export interface IMyUnionWithField2Args {
     field1?: void;
-    field2: number | thrift.Int64;
+    field2: number | string | thrift.Int64;
 }
 export const MyUnionCodec: thrift.IStructToolkit<MyUnionArgs, MyUnion> = {
     create(args: MyUnionArgs): MyUnion {
@@ -33,7 +33,7 @@ export const MyUnionCodec: thrift.IStructToolkit<MyUnionArgs, MyUnion> = {
         }
         if (args.field2 != null) {
             _fieldsSet++;
-            const value_2: thrift.Int64 = (typeof args.field2 === "number" ? new thrift.Int64(args.field2) : args.field2);
+            const value_2: thrift.Int64 = (typeof args.field2 === "number" ? new thrift.Int64(args.field2) : typeof args.field2 === "string" ? thrift.Int64.fromDecimalString(args.field2) : args.field2);
             _returnValue = { field2: value_2 };
         }
         if (_fieldsSet > 1) {
@@ -64,7 +64,7 @@ export const MyUnionCodec: thrift.IStructToolkit<MyUnionArgs, MyUnion> = {
         let _fieldsSet: number = 0;
         const obj = {
             field1: args.field1,
-            field2: (typeof args.field2 === "number" ? new thrift.Int64(args.field2) : args.field2)
+            field2: (typeof args.field2 === "number" ? new thrift.Int64(args.field2) : typeof args.field2 === "string" ? thrift.Int64.fromDecimalString(args.field2) : args.field2)
         };
         output.writeStructBegin("MyUnion");
         if (obj.field1 != null) {

--- a/src/tests/unit/fixtures/thrift-server/basic_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/basic_union.solution.ts
@@ -4,14 +4,14 @@ export interface IMyUnion {
 }
 export interface IMyUnionArgs {
     field1?: number;
-    field2?: number | thrift.Int64;
+    field2?: number | string | thrift.Int64;
 }
 export const MyUnionCodec: thrift.IStructCodec<IMyUnionArgs, IMyUnion> = {
     encode(args: IMyUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
         const obj = {
             field1: args.field1,
-            field2: (typeof args.field2 === "number" ? new thrift.Int64(args.field2) : args.field2)
+            field2: (typeof args.field2 === "number" ? new thrift.Int64(args.field2) : typeof args.field2 === "string" ? thrift.Int64.fromDecimalString(args.field2) : args.field2)
         };
         output.writeStructBegin("MyUnion");
         if (obj.field1 != null) {
@@ -104,7 +104,7 @@ export class MyUnion extends thrift.StructLike implements IMyUnion {
         }
         if (args.field2 != null) {
             _fieldsSet++;
-            const value_4: thrift.Int64 = (typeof args.field2 === "number" ? new thrift.Int64(args.field2) : args.field2);
+            const value_4: thrift.Int64 = (typeof args.field2 === "number" ? new thrift.Int64(args.field2) : typeof args.field2 === "string" ? thrift.Int64.fromDecimalString(args.field2) : args.field2);
             this.field2 = value_4;
         }
         if (_fieldsSet > 1) {

--- a/src/tests/unit/fixtures/thrift-server/basic_union.strict_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/basic_union.strict_union.solution.ts
@@ -20,7 +20,7 @@ export interface IMyUnionWithField1Args {
 }
 export interface IMyUnionWithField2Args {
     field1?: void;
-    field2: number | thrift.Int64;
+    field2: number | string | thrift.Int64;
 }
 export const MyUnionCodec: thrift.IStructToolkit<MyUnionArgs, MyUnion> = {
     create(args: MyUnionArgs): MyUnion {
@@ -33,7 +33,7 @@ export const MyUnionCodec: thrift.IStructToolkit<MyUnionArgs, MyUnion> = {
         }
         if (args.field2 != null) {
             _fieldsSet++;
-            const value_2: thrift.Int64 = (typeof args.field2 === "number" ? new thrift.Int64(args.field2) : args.field2);
+            const value_2: thrift.Int64 = (typeof args.field2 === "number" ? new thrift.Int64(args.field2) : typeof args.field2 === "string" ? thrift.Int64.fromDecimalString(args.field2) : args.field2);
             _returnValue = { field2: value_2 };
         }
         if (_fieldsSet > 1) {
@@ -64,7 +64,7 @@ export const MyUnionCodec: thrift.IStructToolkit<MyUnionArgs, MyUnion> = {
         let _fieldsSet: number = 0;
         const obj = {
             field1: args.field1,
-            field2: (typeof args.field2 === "number" ? new thrift.Int64(args.field2) : args.field2)
+            field2: (typeof args.field2 === "number" ? new thrift.Int64(args.field2) : typeof args.field2 === "string" ? thrift.Int64.fromDecimalString(args.field2) : args.field2)
         };
         output.writeStructBegin("MyUnion");
         if (obj.field1 != null) {

--- a/src/tests/unit/fixtures/thrift-server/complex_nested_struct.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/complex_nested_struct.solution.ts
@@ -3,13 +3,13 @@ export interface IOtherStruct {
     name: Buffer;
 }
 export interface IOtherStructArgs {
-    id: number | thrift.Int64;
+    id: number | string | thrift.Int64;
     name?: string | Buffer;
 }
 export const OtherStructCodec: thrift.IStructCodec<IOtherStructArgs, IOtherStruct> = {
     encode(args: IOtherStructArgs, output: thrift.TProtocol): void {
         const obj = {
-            id: (typeof args.id === "number" ? new thrift.Int64(args.id) : args.id),
+            id: (typeof args.id === "number" ? new thrift.Int64(args.id) : typeof args.id === "string" ? thrift.Int64.fromDecimalString(args.id) : args.id),
             name: (args.name != null ? (typeof args.name === "string" ? Buffer.from(args.name) : args.name) : Buffer.from("John"))
         };
         output.writeStructBegin("OtherStruct");
@@ -85,7 +85,7 @@ export class OtherStruct extends thrift.StructLike implements IOtherStruct {
     constructor(args: IOtherStructArgs) {
         super();
         if (args.id != null) {
-            const value_3: thrift.Int64 = (typeof args.id === "number" ? new thrift.Int64(args.id) : args.id);
+            const value_3: thrift.Int64 = (typeof args.id === "number" ? new thrift.Int64(args.id) : typeof args.id === "string" ? thrift.Int64.fromDecimalString(args.id) : args.id);
             this.id = value_3;
         }
         else {
@@ -121,10 +121,10 @@ export interface IMyStructArgs {
     idMap: Map<string, IOtherStructArgs>;
     idMapList: Map<string, Array<IOtherStructArgs>>;
     idSet: Set<IOtherStructArgs>;
-    intList: Array<number | thrift.Int64>;
+    intList: Array<number | string | thrift.Int64>;
     listList: Array<Array<IOtherStructArgs>>;
     listListString: Array<Array<string>>;
-    i64KeyedMap: Map<number | thrift.Int64, number | thrift.Int64>;
+    i64KeyedMap: Map<number | string | thrift.Int64, number | string | thrift.Int64>;
 }
 export const MyStructCodec: thrift.IStructCodec<IMyStructArgs, IMyStruct> = {
     encode(args: IMyStructArgs, output: thrift.TProtocol): void {
@@ -196,7 +196,7 @@ export const MyStructCodec: thrift.IStructCodec<IMyStructArgs, IMyStruct> = {
         if (obj.intList != null) {
             output.writeFieldBegin("intList", thrift.TType.LIST, 5);
             output.writeListBegin(thrift.TType.I64, obj.intList.length);
-            obj.intList.forEach((value_10: number | thrift.Int64): void => {
+            obj.intList.forEach((value_10: number | string | thrift.Int64): void => {
                 output.writeI64(value_10);
             });
             output.writeListEnd();
@@ -240,7 +240,7 @@ export const MyStructCodec: thrift.IStructCodec<IMyStructArgs, IMyStruct> = {
         if (obj.i64KeyedMap != null) {
             output.writeFieldBegin("i64KeyedMap", thrift.TType.MAP, 8);
             output.writeMapBegin(thrift.TType.I64, thrift.TType.I64, obj.i64KeyedMap.size);
-            obj.i64KeyedMap.forEach((value_15: number | thrift.Int64, key_3: number | thrift.Int64): void => {
+            obj.i64KeyedMap.forEach((value_15: number | string | thrift.Int64, key_3: number | string | thrift.Int64): void => {
                 output.writeI64(key_3);
                 output.writeI64(value_15);
             });
@@ -506,8 +506,8 @@ export class MyStruct extends thrift.StructLike implements IMyStruct {
         }
         if (args.intList != null) {
             const value_39: Array<thrift.Int64> = new Array<thrift.Int64>();
-            args.intList.forEach((value_53: number | thrift.Int64): void => {
-                const value_54: thrift.Int64 = (typeof value_53 === "number" ? new thrift.Int64(value_53) : value_53);
+            args.intList.forEach((value_53: number | string | thrift.Int64): void => {
+                const value_54: thrift.Int64 = (typeof value_53 === "number" ? new thrift.Int64(value_53) : typeof value_53 === "string" ? thrift.Int64.fromDecimalString(value_53) : value_53);
                 value_39.push(value_54);
             });
             this.intList = value_39;
@@ -547,9 +547,9 @@ export class MyStruct extends thrift.StructLike implements IMyStruct {
         }
         if (args.i64KeyedMap != null) {
             const value_42: Map<thrift.Int64, thrift.Int64> = new Map<thrift.Int64, thrift.Int64>();
-            args.i64KeyedMap.forEach((value_63: number | thrift.Int64, key_11: number | thrift.Int64): void => {
-                const value_64: thrift.Int64 = (typeof value_63 === "number" ? new thrift.Int64(value_63) : value_63);
-                const key_12: thrift.Int64 = (typeof key_11 === "number" ? new thrift.Int64(key_11) : key_11);
+            args.i64KeyedMap.forEach((value_63: number | string | thrift.Int64, key_11: number | string | thrift.Int64): void => {
+                const value_64: thrift.Int64 = (typeof value_63 === "number" ? new thrift.Int64(value_63) : typeof value_63 === "string" ? thrift.Int64.fromDecimalString(value_63) : value_63);
+                const key_12: thrift.Int64 = (typeof key_11 === "number" ? new thrift.Int64(key_11) : typeof key_11 === "string" ? thrift.Int64.fromDecimalString(key_11) : key_11);
                 value_42.set(key_12, value_64);
             });
             this.i64KeyedMap = value_42;

--- a/src/tests/unit/fixtures/thrift-server/i64_service.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/i64_service.solution.ts
@@ -2,12 +2,12 @@ export interface ICode {
     status?: thrift.Int64;
 }
 export interface ICodeArgs {
-    status?: number | thrift.Int64;
+    status?: number | string | thrift.Int64;
 }
 export const CodeCodec: thrift.IStructCodec<ICodeArgs, ICode> = {
     encode(args: ICodeArgs, output: thrift.TProtocol): void {
         const obj = {
-            status: (typeof args.status === "number" ? new thrift.Int64(args.status) : args.status)
+            status: (typeof args.status === "number" ? new thrift.Int64(args.status) : typeof args.status === "string" ? thrift.Int64.fromDecimalString(args.status) : args.status)
         };
         output.writeStructBegin("Code");
         if (obj.status != null) {
@@ -58,7 +58,7 @@ export class Code extends thrift.StructLike implements ICode {
     constructor(args: ICodeArgs = {}) {
         super();
         if (args.status != null) {
-            const value_2: thrift.Int64 = (typeof args.status === "number" ? new thrift.Int64(args.status) : args.status);
+            const value_2: thrift.Int64 = (typeof args.status === "number" ? new thrift.Int64(args.status) : typeof args.status === "string" ? thrift.Int64.fromDecimalString(args.status) : args.status);
             this.status = value_2;
         }
     }
@@ -323,12 +323,12 @@ export namespace MyService {
         success?: thrift.Int64;
     }
     export interface IPong__ResultArgs {
-        success?: number | thrift.Int64;
+        success?: number | string | thrift.Int64;
     }
     export const Pong__ResultCodec: thrift.IStructCodec<IPong__ResultArgs, IPong__Result> = {
         encode(args: IPong__ResultArgs, output: thrift.TProtocol): void {
             const obj = {
-                success: (typeof args.success === "number" ? new thrift.Int64(args.success) : args.success)
+                success: (typeof args.success === "number" ? new thrift.Int64(args.success) : typeof args.success === "string" ? thrift.Int64.fromDecimalString(args.success) : args.success)
             };
             output.writeStructBegin("Pong__Result");
             if (obj.success != null) {
@@ -379,7 +379,7 @@ export namespace MyService {
         constructor(args: IPong__ResultArgs = {}) {
             super();
             if (args.success != null) {
-                const value_10: thrift.Int64 = (typeof args.success === "number" ? new thrift.Int64(args.success) : args.success);
+                const value_10: thrift.Int64 = (typeof args.success === "number" ? new thrift.Int64(args.success) : typeof args.success === "string" ? thrift.Int64.fromDecimalString(args.success) : args.success);
                 this.success = value_10;
             }
         }
@@ -481,7 +481,7 @@ export namespace MyService {
     }
     export interface IHandler<Context = any> {
         peg(name: string, context?: Context): string | Promise<string>;
-        pong(code?: ICode, context?: Context): (number | thrift.Int64) | Promise<number | thrift.Int64>;
+        pong(code?: ICode, context?: Context): (number | string | thrift.Int64) | Promise<number | string | thrift.Int64>;
     }
     export class Processor<Context = any> extends thrift.ThriftProcessor<Context, IHandler<Context>> {
         protected readonly _handler: IHandler<Context>;
@@ -551,7 +551,7 @@ export namespace MyService {
             });
         }
         public process_pong(requestId: number, input: thrift.TProtocol, output: thrift.TProtocol, context: Context): Promise<Buffer> {
-            return new Promise<number | thrift.Int64>((resolve, reject): void => {
+            return new Promise<number | string | thrift.Int64>((resolve, reject): void => {
                 try {
                     const args: IPong__Args = Pong__ArgsCodec.decode(input);
                     input.readMessageEnd();
@@ -560,7 +560,7 @@ export namespace MyService {
                 catch (err) {
                     reject(err);
                 }
-            }).then((data: number | thrift.Int64): Buffer => {
+            }).then((data: number | string | thrift.Int64): Buffer => {
                 const result: IPong__ResultArgs = { success: data };
                 output.writeMessageBegin("pong", thrift.MessageType.REPLY, requestId);
                 Pong__ResultCodec.encode(result, output);

--- a/src/tests/unit/fixtures/thrift-server/multi_field_struct.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/multi_field_struct.solution.ts
@@ -7,7 +7,7 @@ export interface IMyStruct {
 }
 export interface IMyStructArgs {
     id?: number;
-    bigID?: number | thrift.Int64;
+    bigID?: number | string | thrift.Int64;
     word: string;
     field1?: number;
     blob?: string | Buffer;
@@ -16,7 +16,7 @@ export const MyStructCodec: thrift.IStructCodec<IMyStructArgs, IMyStruct> = {
     encode(args: IMyStructArgs, output: thrift.TProtocol): void {
         const obj = {
             id: (args.id != null ? args.id : 45),
-            bigID: (args.bigID != null ? (typeof args.bigID === "number" ? new thrift.Int64(args.bigID) : args.bigID) : thrift.Int64.fromDecimalString("23948234")),
+            bigID: (args.bigID != null ? (typeof args.bigID === "number" ? new thrift.Int64(args.bigID) : typeof args.bigID === "string" ? thrift.Int64.fromDecimalString(args.bigID) : args.bigID) : thrift.Int64.fromDecimalString("23948234")),
             word: args.word,
             field1: args.field1,
             blob: (args.blob != null ? (typeof args.blob === "string" ? Buffer.from(args.blob) : args.blob) : Buffer.from("binary"))
@@ -146,7 +146,7 @@ export class MyStruct extends thrift.StructLike implements IMyStruct {
             this.id = value_6;
         }
         if (args.bigID != null) {
-            const value_7: thrift.Int64 = (typeof args.bigID === "number" ? new thrift.Int64(args.bigID) : args.bigID);
+            const value_7: thrift.Int64 = (typeof args.bigID === "number" ? new thrift.Int64(args.bigID) : typeof args.bigID === "string" ? thrift.Int64.fromDecimalString(args.bigID) : args.bigID);
             this.bigID = value_7;
         }
         if (args.word != null) {

--- a/src/tests/unit/fixtures/thrift-server/nested_exception.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/nested_exception.solution.ts
@@ -3,13 +3,13 @@ export interface ICode {
     data?: Buffer;
 }
 export interface ICodeArgs {
-    status?: number | thrift.Int64;
+    status?: number | string | thrift.Int64;
     data?: string | Buffer;
 }
 export const CodeCodec: thrift.IStructCodec<ICodeArgs, ICode> = {
     encode(args: ICodeArgs, output: thrift.TProtocol): void {
         const obj = {
-            status: (args.status != null ? (typeof args.status === "number" ? new thrift.Int64(args.status) : args.status) : thrift.Int64.fromDecimalString("200")),
+            status: (args.status != null ? (typeof args.status === "number" ? new thrift.Int64(args.status) : typeof args.status === "string" ? thrift.Int64.fromDecimalString(args.status) : args.status) : thrift.Int64.fromDecimalString("200")),
             data: (args.data != null ? (typeof args.data === "string" ? Buffer.from(args.data) : args.data) : Buffer.from("data"))
         };
         output.writeStructBegin("Code");
@@ -77,7 +77,7 @@ export class Code extends thrift.StructLike implements ICode {
     constructor(args: ICodeArgs = {}) {
         super();
         if (args.status != null) {
-            const value_3: thrift.Int64 = (typeof args.status === "number" ? new thrift.Int64(args.status) : args.status);
+            const value_3: thrift.Int64 = (typeof args.status === "number" ? new thrift.Int64(args.status) : typeof args.status === "string" ? thrift.Int64.fromDecimalString(args.status) : args.status);
             this.status = value_3;
         }
         if (args.data != null) {

--- a/src/tests/unit/fixtures/thrift-server/nested_struct.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/nested_struct.solution.ts
@@ -4,13 +4,13 @@ export interface IUser {
 }
 export interface IUserArgs {
     name: string;
-    age?: number | thrift.Int64;
+    age?: number | string | thrift.Int64;
 }
 export const UserCodec: thrift.IStructCodec<IUserArgs, IUser> = {
     encode(args: IUserArgs, output: thrift.TProtocol): void {
         const obj = {
             name: args.name,
-            age: (args.age != null ? (typeof args.age === "number" ? new thrift.Int64(args.age) : args.age) : thrift.Int64.fromDecimalString("45"))
+            age: (args.age != null ? (typeof args.age === "number" ? new thrift.Int64(args.age) : typeof args.age === "string" ? thrift.Int64.fromDecimalString(args.age) : args.age) : thrift.Int64.fromDecimalString("45"))
         };
         output.writeStructBegin("User");
         if (obj.name != null) {
@@ -92,7 +92,7 @@ export class User extends thrift.StructLike implements IUser {
             throw new thrift.TProtocolException(thrift.TProtocolExceptionType.UNKNOWN, "Required field[name] is unset!");
         }
         if (args.age != null) {
-            const value_4: thrift.Int64 = (typeof args.age === "number" ? new thrift.Int64(args.age) : args.age);
+            const value_4: thrift.Int64 = (typeof args.age === "number" ? new thrift.Int64(args.age) : typeof args.age === "string" ? thrift.Int64.fromDecimalString(args.age) : args.age);
             this.age = value_4;
         }
     }

--- a/src/tests/unit/fixtures/thrift-server/nested_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/nested_union.solution.ts
@@ -4,14 +4,14 @@ export interface IOption {
 }
 export interface IOptionArgs {
     option1?: string | Buffer;
-    option2?: number | thrift.Int64;
+    option2?: number | string | thrift.Int64;
 }
 export const OptionCodec: thrift.IStructCodec<IOptionArgs, IOption> = {
     encode(args: IOptionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
         const obj = {
             option1: (typeof args.option1 === "string" ? Buffer.from(args.option1) : args.option1),
-            option2: (typeof args.option2 === "number" ? new thrift.Int64(args.option2) : args.option2)
+            option2: (typeof args.option2 === "number" ? new thrift.Int64(args.option2) : typeof args.option2 === "string" ? thrift.Int64.fromDecimalString(args.option2) : args.option2)
         };
         output.writeStructBegin("Option");
         if (obj.option1 != null) {
@@ -104,7 +104,7 @@ export class Option extends thrift.StructLike implements IOption {
         }
         if (args.option2 != null) {
             _fieldsSet++;
-            const value_4: thrift.Int64 = (typeof args.option2 === "number" ? new thrift.Int64(args.option2) : args.option2);
+            const value_4: thrift.Int64 = (typeof args.option2 === "number" ? new thrift.Int64(args.option2) : typeof args.option2 === "string" ? thrift.Int64.fromDecimalString(args.option2) : args.option2);
             this.option2 = value_4;
         }
         if (_fieldsSet > 1) {


### PR DESCRIPTION
This PR changes the "loose" representation of `i64` to be `number | string | thrift.Int64`. Previously this was `number | thrift.Int64`.

Because we can't confidently represent the full range of 64-bit integers in the JavaScript `number` type (we'll explore `bigint` in the future) we have to use a wrapper type `Int64` to maintain precision. Values that are generated in JS are very unlikely to actually need the full precision and can therefore be represented as `number` in user code. Another work around for users is to pass 64-bit integers as `string`. In the generated code we can handle these conversions for the user and allow them to represent these numbers as makes sense to their app.