### PR TITLE
Add explicit type to temporary object when encoding structs and unions

### DIFF
--- a/src/main/render/thrift-server/struct/encode.ts
+++ b/src/main/render/thrift-server/struct/encode.ts
@@ -54,7 +54,10 @@ export function createTempVariables(
         return [
             createConstStatement(
                 COMMON_IDENTIFIERS.obj,
-                undefined,
+                ts.createTypeReferenceNode(
+                    ts.createIdentifier(looseNameForStruct(node, state)),
+                    undefined,
+                ),
                 ts.createObjectLiteral(
                     node.fields.map(
                         (

--- a/src/tests/unit/fixtures/apache/generated/SharedStruct.ts
+++ b/src/tests/unit/fixtures/apache/generated/SharedStruct.ts
@@ -8,10 +8,12 @@ import * as Code from "./Code";
 export interface ISharedStructArgs {
     code: Code.Code;
     value: string;
+    mapWithDefault?: Map<string, string>;
 }
 export class SharedStruct {
     public code: Code.Code;
     public value: string;
+    public mapWithDefault?: Map<string, string> = new Map([]);
     constructor(args: ISharedStructArgs) {
         if (args != null && args.code != null) {
             this.code = args.code;
@@ -25,6 +27,9 @@ export class SharedStruct {
         else {
             throw new thrift.Thrift.TProtocolException(thrift.Thrift.TProtocolExceptionType.UNKNOWN, "Required field[value] is unset!");
         }
+        if (args != null && args.mapWithDefault != null) {
+            this.mapWithDefault = args.mapWithDefault;
+        }
     }
     public write(output: thrift.TProtocol): void {
         output.writeStructBegin("SharedStruct");
@@ -36,6 +41,16 @@ export class SharedStruct {
         if (this.value != null) {
             output.writeFieldBegin("value", thrift.Thrift.Type.STRING, 2);
             output.writeString(this.value);
+            output.writeFieldEnd();
+        }
+        if (this.mapWithDefault != null) {
+            output.writeFieldBegin("mapWithDefault", thrift.Thrift.Type.MAP, 3);
+            output.writeMapBegin(thrift.Thrift.Type.STRING, thrift.Thrift.Type.STRING, this.mapWithDefault.size);
+            this.mapWithDefault.forEach((value_1: string, key_1: string): void => {
+                output.writeString(key_1);
+                output.writeString(value_1);
+            });
+            output.writeMapEnd();
             output.writeFieldEnd();
         }
         output.writeFieldStop();
@@ -55,8 +70,8 @@ export class SharedStruct {
             switch (fieldId) {
                 case 1:
                     if (fieldType === thrift.Thrift.Type.STRUCT) {
-                        const value_1: Code.Code = Code.Code.read(input);
-                        _args.code = value_1;
+                        const value_2: Code.Code = Code.Code.read(input);
+                        _args.code = value_2;
                     }
                     else {
                         input.skip(fieldType);
@@ -64,8 +79,25 @@ export class SharedStruct {
                     break;
                 case 2:
                     if (fieldType === thrift.Thrift.Type.STRING) {
-                        const value_2: string = input.readString();
-                        _args.value = value_2;
+                        const value_3: string = input.readString();
+                        _args.value = value_3;
+                    }
+                    else {
+                        input.skip(fieldType);
+                    }
+                    break;
+                case 3:
+                    if (fieldType === thrift.Thrift.Type.MAP) {
+                        const value_4: Map<string, string> = new Map<string, string>();
+                        const metadata_1: thrift.TMap = input.readMapBegin();
+                        const size_1: number = metadata_1.size;
+                        for (let i_1: number = 0; i_1 < size_1; i_1++) {
+                            const key_2: string = input.readString();
+                            const value_5: string = input.readString();
+                            value_4.set(key_2, value_5);
+                        }
+                        input.readMapEnd();
+                        _args.mapWithDefault = value_4;
                     }
                     else {
                         input.skip(fieldType);

--- a/src/tests/unit/fixtures/thrift-server/annotations_exception.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/annotations_exception.solution.ts
@@ -9,7 +9,7 @@ export interface IMyExceptionArgs {
 }
 export const MyExceptionCodec: thrift.IStructCodec<IMyExceptionArgs, IMyException> = {
     encode(args: IMyExceptionArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IMyExceptionArgs = {
             message: args.message,
             code: (args.code != null ? args.code : 200)
         };

--- a/src/tests/unit/fixtures/thrift-server/annotations_service.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/annotations_service.solution.ts
@@ -9,7 +9,7 @@ export interface IUserArgs {
 }
 export const UserCodec: thrift.IStructCodec<IUserArgs, IUser> = {
     encode(args: IUserArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IUserArgs = {
             name: args.name,
             id: args.id
         };
@@ -160,7 +160,7 @@ export interface IGetUser__ArgsArgs {
 }
 export const GetUser__ArgsCodec: thrift.IStructCodec<IGetUser__ArgsArgs, IGetUser__Args> = {
     encode(args: IGetUser__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IGetUser__ArgsArgs = {
             id: args.id
         };
         output.writeStructBegin("GetUser__Args");
@@ -248,7 +248,7 @@ export interface ISaveUser__ArgsArgs {
 }
 export const SaveUser__ArgsCodec: thrift.IStructCodec<ISaveUser__ArgsArgs, ISaveUser__Args> = {
     encode(args: ISaveUser__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: ISaveUser__ArgsArgs = {
             user: args.user
         };
         output.writeStructBegin("SaveUser__Args");
@@ -387,7 +387,7 @@ export interface IGetUser__ResultArgs {
 }
 export const GetUser__ResultCodec: thrift.IStructCodec<IGetUser__ResultArgs, IGetUser__Result> = {
     encode(args: IGetUser__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IGetUser__ResultArgs = {
             success: args.success
         };
         output.writeStructBegin("GetUser__Result");

--- a/src/tests/unit/fixtures/thrift-server/annotations_struct.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/annotations_struct.solution.ts
@@ -9,7 +9,7 @@ export interface IMyStructArgs {
 }
 export const MyStructCodec: thrift.IStructCodec<IMyStructArgs, IMyStruct> = {
     encode(args: IMyStructArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IMyStructArgs = {
             id: (args.id != null ? args.id : 45),
             bigID: (args.bigID != null ? (typeof args.bigID === "number" ? new thrift.Int64(args.bigID) : typeof args.bigID === "string" ? thrift.Int64.fromDecimalString(args.bigID) : args.bigID) : thrift.Int64.fromDecimalString("23948234"))
         };

--- a/src/tests/unit/fixtures/thrift-server/annotations_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/annotations_union.solution.ts
@@ -10,7 +10,7 @@ export interface IMyUnionArgs {
 export const MyUnionCodec: thrift.IStructCodec<IMyUnionArgs, IMyUnion> = {
     encode(args: IMyUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj = {
+        const obj: IMyUnionArgs = {
             field1: args.field1,
             field2: (typeof args.field2 === "number" ? new thrift.Int64(args.field2) : typeof args.field2 === "string" ? thrift.Int64.fromDecimalString(args.field2) : args.field2)
         };

--- a/src/tests/unit/fixtures/thrift-server/basic_exception.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/basic_exception.solution.ts
@@ -9,7 +9,7 @@ export interface IMyExceptionArgs {
 }
 export const MyExceptionCodec: thrift.IStructCodec<IMyExceptionArgs, IMyException> = {
     encode(args: IMyExceptionArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IMyExceptionArgs = {
             message: args.message,
             code: (args.code != null ? args.code : 200)
         };

--- a/src/tests/unit/fixtures/thrift-server/basic_service.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/basic_service.solution.ts
@@ -9,7 +9,7 @@ export interface IUserArgs {
 }
 export const UserCodec: thrift.IStructCodec<IUserArgs, IUser> = {
     encode(args: IUserArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IUserArgs = {
             name: args.name,
             id: args.id
         };
@@ -148,7 +148,7 @@ export interface IGetUser__ArgsArgs {
 }
 export const GetUser__ArgsCodec: thrift.IStructCodec<IGetUser__ArgsArgs, IGetUser__Args> = {
     encode(args: IGetUser__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IGetUser__ArgsArgs = {
             id: args.id
         };
         output.writeStructBegin("GetUser__Args");
@@ -236,7 +236,7 @@ export interface ISaveUser__ArgsArgs {
 }
 export const SaveUser__ArgsCodec: thrift.IStructCodec<ISaveUser__ArgsArgs, ISaveUser__Args> = {
     encode(args: ISaveUser__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: ISaveUser__ArgsArgs = {
             user: args.user
         };
         output.writeStructBegin("SaveUser__Args");
@@ -375,7 +375,7 @@ export interface IGetUser__ResultArgs {
 }
 export const GetUser__ResultCodec: thrift.IStructCodec<IGetUser__ResultArgs, IGetUser__Result> = {
     encode(args: IGetUser__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IGetUser__ResultArgs = {
             success: args.success
         };
         output.writeStructBegin("GetUser__Result");

--- a/src/tests/unit/fixtures/thrift-server/basic_service.strict_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/basic_service.strict_union.solution.ts
@@ -66,7 +66,7 @@ export const MyUnionCodec: thrift.IStructToolkit<MyUnionArgs, MyUnion> = {
     },
     encode(args: MyUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj = {
+        const obj: MyUnionArgs = {
             field1: args.field1,
             field2: (typeof args.field2 === "number" ? new thrift.Int64(args.field2) : typeof args.field2 === "string" ? thrift.Int64.fromDecimalString(args.field2) : args.field2)
         };
@@ -187,7 +187,7 @@ export interface IGetUser__ArgsArgs {
 }
 export const GetUser__ArgsCodec: thrift.IStructCodec<IGetUser__ArgsArgs, IGetUser__Args> = {
     encode(args: IGetUser__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IGetUser__ArgsArgs = {
             arg1: args.arg1
         };
         output.writeStructBegin("GetUser__Args");
@@ -326,7 +326,7 @@ export interface IGetUser__ResultArgs {
 }
 export const GetUser__ResultCodec: thrift.IStructCodec<IGetUser__ResultArgs, IGetUser__Result> = {
     encode(args: IGetUser__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IGetUser__ResultArgs = {
             success: args.success
         };
         output.writeStructBegin("GetUser__Result");

--- a/src/tests/unit/fixtures/thrift-server/basic_struct.no_name.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/basic_struct.no_name.solution.ts
@@ -6,7 +6,7 @@ export interface IMyStructArgs {
 }
 export const MyStructCodec: thrift.IStructCodec<IMyStructArgs, IMyStruct> = {
     encode(args: IMyStructArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IMyStructArgs = {
             id: args.id
         };
         output.writeStructBegin("MyStruct");

--- a/src/tests/unit/fixtures/thrift-server/basic_struct.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/basic_struct.solution.ts
@@ -15,7 +15,7 @@ export interface IMyStructArgs {
 }
 export const MyStructCodec: thrift.IStructCodec<IMyStructArgs, IMyStruct> = {
     encode(args: IMyStructArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IMyStructArgs = {
             id: (args.id != null ? args.id : 45),
             bigID: (args.bigID != null ? (typeof args.bigID === "number" ? new thrift.Int64(args.bigID) : typeof args.bigID === "string" ? thrift.Int64.fromDecimalString(args.bigID) : args.bigID) : thrift.Int64.fromDecimalString("23948234")),
             word: args.word,

--- a/src/tests/unit/fixtures/thrift-server/basic_union.no_name.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/basic_union.no_name.solution.ts
@@ -9,7 +9,7 @@ export interface IMyUnionArgs {
 export const MyUnionCodec: thrift.IStructCodec<IMyUnionArgs, IMyUnion> = {
     encode(args: IMyUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj = {
+        const obj: IMyUnionArgs = {
             option1: args.option1,
             option2: (typeof args.option2 === "number" ? new thrift.Int64(args.option2) : typeof args.option2 === "string" ? thrift.Int64.fromDecimalString(args.option2) : args.option2)
         };

--- a/src/tests/unit/fixtures/thrift-server/basic_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/basic_union.solution.ts
@@ -10,7 +10,7 @@ export interface IMyUnionArgs {
 export const MyUnionCodec: thrift.IStructCodec<IMyUnionArgs, IMyUnion> = {
     encode(args: IMyUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj = {
+        const obj: IMyUnionArgs = {
             option1: args.option1,
             option2: (typeof args.option2 === "number" ? new thrift.Int64(args.option2) : typeof args.option2 === "string" ? thrift.Int64.fromDecimalString(args.option2) : args.option2)
         };

--- a/src/tests/unit/fixtures/thrift-server/basic_union.strict_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/basic_union.strict_union.solution.ts
@@ -66,7 +66,7 @@ export const MyUnionCodec: thrift.IStructToolkit<MyUnionArgs, MyUnion> = {
     },
     encode(args: MyUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj = {
+        const obj: MyUnionArgs = {
             field1: args.field1,
             field2: (typeof args.field2 === "number" ? new thrift.Int64(args.field2) : typeof args.field2 === "string" ? thrift.Int64.fromDecimalString(args.field2) : args.field2)
         };

--- a/src/tests/unit/fixtures/thrift-server/complex_nested_struct.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/complex_nested_struct.solution.ts
@@ -9,7 +9,7 @@ export interface IOtherStructArgs {
 }
 export const OtherStructCodec: thrift.IStructCodec<IOtherStructArgs, IOtherStruct> = {
     encode(args: IOtherStructArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IOtherStructArgs = {
             id: (typeof args.id === "number" ? new thrift.Int64(args.id) : typeof args.id === "string" ? thrift.Int64.fromDecimalString(args.id) : args.id),
             name: (args.name != null ? (typeof args.name === "string" ? Buffer.from(args.name) : args.name) : Buffer.from("John"))
         };
@@ -132,7 +132,7 @@ export interface IMyStructArgs {
 }
 export const MyStructCodec: thrift.IStructCodec<IMyStructArgs, IMyStruct> = {
     encode(args: IMyStructArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IMyStructArgs = {
             idList: args.idList,
             idMap: args.idMap,
             idMapList: args.idMapList,

--- a/src/tests/unit/fixtures/thrift-server/complex_typedef.strict_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/complex_typedef.strict_union.solution.ts
@@ -70,7 +70,7 @@ export const MyUnionCodec: thrift.IStructToolkit<MyUnionArgs, MyUnion> = {
     },
     encode(args: MyUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj = {
+        const obj: MyUnionArgs = {
             option1: args.option1,
             option2: args.option2
         };

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/Code.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/Code.ts
@@ -13,7 +13,7 @@ export interface ICodeArgs {
 }
 export const CodeCodec: thrift.IStructCodec<ICodeArgs, ICode> = {
     encode(args: ICodeArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: ICodeArgs = {
             status: (typeof args.status === "number" ? new thrift.Int64(args.status) : typeof args.status === "string" ? thrift.Int64.fromDecimalString(args.status) : args.status)
         };
         output.writeStructBegin("Code");

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/SharedService.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/SharedService.ts
@@ -40,7 +40,7 @@ export interface IGetUnion__ArgsArgs {
 }
 export const GetUnion__ArgsCodec: thrift.IStructCodec<IGetUnion__ArgsArgs, IGetUnion__Args> = {
     encode(args: IGetUnion__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IGetUnion__ArgsArgs = {
             index: args.index
         };
         output.writeStructBegin("GetUnion__Args");
@@ -179,7 +179,7 @@ export interface IGetUnion__ResultArgs {
 }
 export const GetUnion__ResultCodec: thrift.IStructCodec<IGetUnion__ResultArgs, IGetUnion__Result> = {
     encode(args: IGetUnion__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IGetUnion__ResultArgs = {
             success: args.success
         };
         output.writeStructBegin("GetUnion__Result");
@@ -256,7 +256,7 @@ export interface IGetEnum__ResultArgs {
 }
 export const GetEnum__ResultCodec: thrift.IStructCodec<IGetEnum__ResultArgs, IGetEnum__Result> = {
     encode(args: IGetEnum__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IGetEnum__ResultArgs = {
             success: args.success
         };
         output.writeStructBegin("GetEnum__Result");

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/SharedServiceBase.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/SharedServiceBase.ts
@@ -28,7 +28,7 @@ export interface IGetStruct__ArgsArgs {
 }
 export const GetStruct__ArgsCodec: thrift.IStructCodec<IGetStruct__ArgsArgs, IGetStruct__Args> = {
     encode(args: IGetStruct__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IGetStruct__ArgsArgs = {
             key: args.key
         };
         output.writeStructBegin("GetStruct__Args");
@@ -116,7 +116,7 @@ export interface IGetStruct__ResultArgs {
 }
 export const GetStruct__ResultCodec: thrift.IStructCodec<IGetStruct__ResultArgs, IGetStruct__Result> = {
     encode(args: IGetStruct__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IGetStruct__ResultArgs = {
             success: args.success
         };
         output.writeStructBegin("GetStruct__Result");

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/SharedStruct.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/SharedStruct.ts
@@ -9,16 +9,19 @@ export interface ISharedStruct {
     __name: "SharedStruct";
     code: Code.ICode;
     value: string;
+    mapWithDefault?: Map<string, string>;
 }
 export interface ISharedStructArgs {
     code: Code.ICodeArgs;
     value: string;
+    mapWithDefault?: Map<string, string>;
 }
 export const SharedStructCodec: thrift.IStructCodec<ISharedStructArgs, ISharedStruct> = {
     encode(args: ISharedStructArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: ISharedStructArgs = {
             code: args.code,
-            value: args.value
+            value: args.value,
+            mapWithDefault: (args.mapWithDefault != null ? args.mapWithDefault : new Map([]))
         };
         output.writeStructBegin("SharedStruct");
         if (obj.code != null) {
@@ -37,6 +40,16 @@ export const SharedStructCodec: thrift.IStructCodec<ISharedStructArgs, ISharedSt
         else {
             throw new thrift.TProtocolException(thrift.TProtocolExceptionType.UNKNOWN, "Required field[value] is unset!");
         }
+        if (obj.mapWithDefault != null) {
+            output.writeFieldBegin("mapWithDefault", thrift.TType.MAP, 3);
+            output.writeMapBegin(thrift.TType.STRING, thrift.TType.STRING, obj.mapWithDefault.size);
+            obj.mapWithDefault.forEach((value_1: string, key_1: string): void => {
+                output.writeString(key_1);
+                output.writeString(value_1);
+            });
+            output.writeMapEnd();
+            output.writeFieldEnd();
+        }
         output.writeFieldStop();
         output.writeStructEnd();
         return;
@@ -54,8 +67,8 @@ export const SharedStructCodec: thrift.IStructCodec<ISharedStructArgs, ISharedSt
             switch (fieldId) {
                 case 1:
                     if (fieldType === thrift.TType.STRUCT) {
-                        const value_1: Code.ICode = Code.CodeCodec.decode(input);
-                        _args.code = value_1;
+                        const value_2: Code.ICode = Code.CodeCodec.decode(input);
+                        _args.code = value_2;
                     }
                     else {
                         input.skip(fieldType);
@@ -63,8 +76,25 @@ export const SharedStructCodec: thrift.IStructCodec<ISharedStructArgs, ISharedSt
                     break;
                 case 2:
                     if (fieldType === thrift.TType.STRING) {
-                        const value_2: string = input.readString();
-                        _args.value = value_2;
+                        const value_3: string = input.readString();
+                        _args.value = value_3;
+                    }
+                    else {
+                        input.skip(fieldType);
+                    }
+                    break;
+                case 3:
+                    if (fieldType === thrift.TType.MAP) {
+                        const value_4: Map<string, string> = new Map<string, string>();
+                        const metadata_1: thrift.IThriftMap = input.readMapBegin();
+                        const size_1: number = metadata_1.size;
+                        for (let i_1: number = 0; i_1 < size_1; i_1++) {
+                            const key_2: string = input.readString();
+                            const value_5: string = input.readString();
+                            value_4.set(key_2, value_5);
+                        }
+                        input.readMapEnd();
+                        _args.mapWithDefault = value_4;
                     }
                     else {
                         input.skip(fieldType);
@@ -81,7 +111,8 @@ export const SharedStructCodec: thrift.IStructCodec<ISharedStructArgs, ISharedSt
             return {
                 __name: "SharedStruct",
                 code: _args.code,
-                value: _args.value
+                value: _args.value,
+                mapWithDefault: (_args.mapWithDefault != null ? _args.mapWithDefault : new Map([]))
             };
         }
         else {
@@ -92,24 +123,34 @@ export const SharedStructCodec: thrift.IStructCodec<ISharedStructArgs, ISharedSt
 export class SharedStruct extends thrift.StructLike implements ISharedStruct {
     public code: Code.ICode;
     public value: string;
+    public mapWithDefault?: Map<string, string> = new Map([]);
     public readonly __name = "SharedStruct";
     public readonly _annotations: thrift.IThriftAnnotations = {};
     public readonly _fieldAnnotations: thrift.IFieldAnnotations = {};
     constructor(args: ISharedStructArgs) {
         super();
         if (args.code != null) {
-            const value_3: Code.ICode = new Code.Code(args.code);
-            this.code = value_3;
+            const value_6: Code.ICode = new Code.Code(args.code);
+            this.code = value_6;
         }
         else {
             throw new thrift.TProtocolException(thrift.TProtocolExceptionType.UNKNOWN, "Required field[code] is unset!");
         }
         if (args.value != null) {
-            const value_4: string = args.value;
-            this.value = value_4;
+            const value_7: string = args.value;
+            this.value = value_7;
         }
         else {
             throw new thrift.TProtocolException(thrift.TProtocolExceptionType.UNKNOWN, "Required field[value] is unset!");
+        }
+        if (args.mapWithDefault != null) {
+            const value_8: Map<string, string> = new Map<string, string>();
+            args.mapWithDefault.forEach((value_9: string, key_3: string): void => {
+                const value_10: string = value_9;
+                const key_4: string = key_3;
+                value_8.set(key_4, value_10);
+            });
+            this.mapWithDefault = value_8;
         }
     }
     public static read(input: thrift.TProtocol): SharedStruct {

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/SharedUnion.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/SharedUnion.ts
@@ -72,7 +72,7 @@ export const SharedUnionCodec: thrift.IStructToolkit<SharedUnionArgs, SharedUnio
     },
     encode(args: SharedUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj = {
+        const obj: SharedUnionArgs = {
             option1: args.option1,
             option2: args.option2
         };

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/calculator/Calculator.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/calculator/Calculator.ts
@@ -173,7 +173,7 @@ export interface IAdd__ArgsArgs {
 }
 export const Add__ArgsCodec: thrift.IStructCodec<IAdd__ArgsArgs, IAdd__Args> = {
     encode(args: IAdd__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IAdd__ArgsArgs = {
             num1: args.num1,
             num2: args.num2
         };
@@ -290,7 +290,7 @@ export interface IAddInt64__ArgsArgs {
 }
 export const AddInt64__ArgsCodec: thrift.IStructCodec<IAddInt64__ArgsArgs, IAddInt64__Args> = {
     encode(args: IAddInt64__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IAddInt64__ArgsArgs = {
             num1: (typeof args.num1 === "number" ? new thrift.Int64(args.num1) : typeof args.num1 === "string" ? thrift.Int64.fromDecimalString(args.num1) : args.num1),
             num2: (typeof args.num2 === "number" ? new thrift.Int64(args.num2) : typeof args.num2 === "string" ? thrift.Int64.fromDecimalString(args.num2) : args.num2)
         };
@@ -407,7 +407,7 @@ export interface IAddWithContext__ArgsArgs {
 }
 export const AddWithContext__ArgsCodec: thrift.IStructCodec<IAddWithContext__ArgsArgs, IAddWithContext__Args> = {
     encode(args: IAddWithContext__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IAddWithContext__ArgsArgs = {
             num1: args.num1,
             num2: args.num2
         };
@@ -524,7 +524,7 @@ export interface ICalculate__ArgsArgs {
 }
 export const Calculate__ArgsCodec: thrift.IStructCodec<ICalculate__ArgsArgs, ICalculate__Args> = {
     encode(args: ICalculate__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: ICalculate__ArgsArgs = {
             logid: args.logid,
             work: args.work
         };
@@ -639,7 +639,7 @@ export interface IEchoBinary__ArgsArgs {
 }
 export const EchoBinary__ArgsCodec: thrift.IStructCodec<IEchoBinary__ArgsArgs, IEchoBinary__Args> = {
     encode(args: IEchoBinary__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IEchoBinary__ArgsArgs = {
             word: (typeof args.word === "string" ? Buffer.from(args.word) : args.word)
         };
         output.writeStructBegin("EchoBinary__Args");
@@ -727,7 +727,7 @@ export interface IEchoString__ArgsArgs {
 }
 export const EchoString__ArgsCodec: thrift.IStructCodec<IEchoString__ArgsArgs, IEchoString__Args> = {
     encode(args: IEchoString__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IEchoString__ArgsArgs = {
             word: args.word
         };
         output.writeStructBegin("EchoString__Args");
@@ -815,7 +815,7 @@ export interface ICheckName__ArgsArgs {
 }
 export const CheckName__ArgsCodec: thrift.IStructCodec<ICheckName__ArgsArgs, ICheckName__Args> = {
     encode(args: ICheckName__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: ICheckName__ArgsArgs = {
             choice: args.choice
         };
         output.writeStructBegin("CheckName__Args");
@@ -903,7 +903,7 @@ export interface ICheckOptional__ArgsArgs {
 }
 export const CheckOptional__ArgsCodec: thrift.IStructCodec<ICheckOptional__ArgsArgs, ICheckOptional__Args> = {
     encode(args: ICheckOptional__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: ICheckOptional__ArgsArgs = {
             type: args.type
         };
         output.writeStructBegin("CheckOptional__Args");
@@ -980,7 +980,7 @@ export interface IMapOneList__ArgsArgs {
 }
 export const MapOneList__ArgsCodec: thrift.IStructCodec<IMapOneList__ArgsArgs, IMapOneList__Args> = {
     encode(args: IMapOneList__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IMapOneList__ArgsArgs = {
             arg: args.arg
         };
         output.writeStructBegin("MapOneList__Args");
@@ -1083,7 +1083,7 @@ export interface IMapValues__ArgsArgs {
 }
 export const MapValues__ArgsCodec: thrift.IStructCodec<IMapValues__ArgsArgs, IMapValues__Args> = {
     encode(args: IMapValues__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IMapValues__ArgsArgs = {
             arg: args.arg
         };
         output.writeStructBegin("MapValues__Args");
@@ -1189,7 +1189,7 @@ export interface IListToMap__ArgsArgs {
 }
 export const ListToMap__ArgsCodec: thrift.IStructCodec<IListToMap__ArgsArgs, IListToMap__Args> = {
     encode(args: IListToMap__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IListToMap__ArgsArgs = {
             arg: args.arg
         };
         output.writeStructBegin("ListToMap__Args");
@@ -1530,7 +1530,7 @@ export interface IAdd__ResultArgs {
 }
 export const Add__ResultCodec: thrift.IStructCodec<IAdd__ResultArgs, IAdd__Result> = {
     encode(args: IAdd__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IAdd__ResultArgs = {
             success: args.success,
             exp: args.exp
         };
@@ -1630,7 +1630,7 @@ export interface IAddInt64__ResultArgs {
 }
 export const AddInt64__ResultCodec: thrift.IStructCodec<IAddInt64__ResultArgs, IAddInt64__Result> = {
     encode(args: IAddInt64__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IAddInt64__ResultArgs = {
             success: (typeof args.success === "number" ? new thrift.Int64(args.success) : typeof args.success === "string" ? thrift.Int64.fromDecimalString(args.success) : args.success),
             exp: args.exp
         };
@@ -1728,7 +1728,7 @@ export interface IAddWithContext__ResultArgs {
 }
 export const AddWithContext__ResultCodec: thrift.IStructCodec<IAddWithContext__ResultArgs, IAddWithContext__Result> = {
     encode(args: IAddWithContext__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IAddWithContext__ResultArgs = {
             success: args.success
         };
         output.writeStructBegin("AddWithContext__Result");
@@ -1807,7 +1807,7 @@ export interface ICalculate__ResultArgs {
 }
 export const Calculate__ResultCodec: thrift.IStructCodec<ICalculate__ResultArgs, ICalculate__Result> = {
     encode(args: ICalculate__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: ICalculate__ResultArgs = {
             success: args.success,
             ouch: args.ouch
         };
@@ -1905,7 +1905,7 @@ export interface IEchoBinary__ResultArgs {
 }
 export const EchoBinary__ResultCodec: thrift.IStructCodec<IEchoBinary__ResultArgs, IEchoBinary__Result> = {
     encode(args: IEchoBinary__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IEchoBinary__ResultArgs = {
             success: args.success
         };
         output.writeStructBegin("EchoBinary__Result");
@@ -1982,7 +1982,7 @@ export interface IEchoString__ResultArgs {
 }
 export const EchoString__ResultCodec: thrift.IStructCodec<IEchoString__ResultArgs, IEchoString__Result> = {
     encode(args: IEchoString__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IEchoString__ResultArgs = {
             success: args.success
         };
         output.writeStructBegin("EchoString__Result");
@@ -2059,7 +2059,7 @@ export interface ICheckName__ResultArgs {
 }
 export const CheckName__ResultCodec: thrift.IStructCodec<ICheckName__ResultArgs, ICheckName__Result> = {
     encode(args: ICheckName__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: ICheckName__ResultArgs = {
             success: args.success
         };
         output.writeStructBegin("CheckName__Result");
@@ -2136,7 +2136,7 @@ export interface ICheckOptional__ResultArgs {
 }
 export const CheckOptional__ResultCodec: thrift.IStructCodec<ICheckOptional__ResultArgs, ICheckOptional__Result> = {
     encode(args: ICheckOptional__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: ICheckOptional__ResultArgs = {
             success: args.success
         };
         output.writeStructBegin("CheckOptional__Result");
@@ -2213,7 +2213,7 @@ export interface IMapOneList__ResultArgs {
 }
 export const MapOneList__ResultCodec: thrift.IStructCodec<IMapOneList__ResultArgs, IMapOneList__Result> = {
     encode(args: IMapOneList__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IMapOneList__ResultArgs = {
             success: args.success
         };
         output.writeStructBegin("MapOneList__Result");
@@ -2305,7 +2305,7 @@ export interface IMapValues__ResultArgs {
 }
 export const MapValues__ResultCodec: thrift.IStructCodec<IMapValues__ResultArgs, IMapValues__Result> = {
     encode(args: IMapValues__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IMapValues__ResultArgs = {
             success: args.success
         };
         output.writeStructBegin("MapValues__Result");
@@ -2397,7 +2397,7 @@ export interface IListToMap__ResultArgs {
 }
 export const ListToMap__ResultCodec: thrift.IStructCodec<IListToMap__ResultArgs, IListToMap__Result> = {
     encode(args: IListToMap__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IListToMap__ResultArgs = {
             success: args.success
         };
         output.writeStructBegin("ListToMap__Result");
@@ -2492,7 +2492,7 @@ export interface IFetchThing__ResultArgs {
 }
 export const FetchThing__ResultCodec: thrift.IStructCodec<IFetchThing__ResultArgs, IFetchThing__Result> = {
     encode(args: IFetchThing__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IFetchThing__ResultArgs = {
             success: args.success
         };
         output.writeStructBegin("FetchThing__Result");
@@ -2569,7 +2569,7 @@ export interface IFetchMap__ResultArgs {
 }
 export const FetchMap__ResultCodec: thrift.IStructCodec<IFetchMap__ResultArgs, IFetchMap__Result> = {
     encode(args: IFetchMap__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IFetchMap__ResultArgs = {
             success: args.success
         };
         output.writeStructBegin("FetchMap__Result");

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/calculator/Choice.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/calculator/Choice.ts
@@ -74,7 +74,7 @@ export const ChoiceCodec: thrift.IStructToolkit<ChoiceArgs, Choice> = {
     },
     encode(args: ChoiceArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj = {
+        const obj: ChoiceArgs = {
             firstName: args.firstName,
             lastName: args.lastName
         };

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/calculator/FirstName.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/calculator/FirstName.ts
@@ -13,7 +13,7 @@ export interface IFirstNameArgs {
 }
 export const FirstNameCodec: thrift.IStructCodec<IFirstNameArgs, IFirstName> = {
     encode(args: IFirstNameArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IFirstNameArgs = {
             name: args.name
         };
         output.writeStructBegin("FirstName");

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/calculator/LastName.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/calculator/LastName.ts
@@ -13,7 +13,7 @@ export interface ILastNameArgs {
 }
 export const LastNameCodec: thrift.IStructCodec<ILastNameArgs, ILastName> = {
     encode(args: ILastNameArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: ILastNameArgs = {
             name: args.name
         };
         output.writeStructBegin("LastName");

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/calculator/NotAGoodIdea.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/calculator/NotAGoodIdea.ts
@@ -17,7 +17,7 @@ export interface INotAGoodIdeaArgs {
 }
 export const NotAGoodIdeaCodec: thrift.IStructCodec<INotAGoodIdeaArgs, INotAGoodIdea> = {
     encode(args: INotAGoodIdeaArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: INotAGoodIdeaArgs = {
             message: args.message,
             data: args.data
         };

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/calculator/Work.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/calculator/Work.ts
@@ -20,7 +20,7 @@ export interface IWorkArgs {
 }
 export const WorkCodec: thrift.IStructCodec<IWorkArgs, IWork> = {
     encode(args: IWorkArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IWorkArgs = {
             num1: (args.num1 != null ? args.num1 : 0),
             num2: args.num2,
             op: (args.op != null ? args.op : Operation.Operation.ADD),

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/common/AuthException.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/common/AuthException.ts
@@ -15,7 +15,7 @@ export interface IAuthExceptionArgs {
 }
 export const AuthExceptionCodec: thrift.IStructCodec<IAuthExceptionArgs, IAuthException> = {
     encode(args: IAuthExceptionArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IAuthExceptionArgs = {
             code: args.code,
             message: args.message
         };

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/common/OtherCommonUnion.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/common/OtherCommonUnion.ts
@@ -72,7 +72,7 @@ export const OtherCommonUnionCodec: thrift.IStructToolkit<OtherCommonUnionArgs, 
     },
     encode(args: OtherCommonUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj = {
+        const obj: OtherCommonUnionArgs = {
             option1: args.option1,
             option2: args.option2
         };

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/exceptions/InvalidOperation.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/exceptions/InvalidOperation.ts
@@ -15,7 +15,7 @@ export interface IInvalidOperationArgs {
 }
 export const InvalidOperationCodec: thrift.IStructCodec<IInvalidOperationArgs, IInvalidOperation> = {
     encode(args: IInvalidOperationArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IInvalidOperationArgs = {
             whatOp: args.whatOp,
             why: args.why
         };

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/exceptions/InvalidResult.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/exceptions/InvalidResult.ts
@@ -16,7 +16,7 @@ export interface IInvalidResultArgs {
 }
 export const InvalidResultCodec: thrift.IStructCodec<IInvalidResultArgs, IInvalidResult> = {
     encode(args: IInvalidResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IInvalidResultArgs = {
             message: args.message,
             code: args.code
         };

--- a/src/tests/unit/fixtures/thrift-server/generated/Code.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/Code.ts
@@ -13,7 +13,7 @@ export interface ICodeArgs {
 }
 export const CodeCodec: thrift.IStructCodec<ICodeArgs, ICode> = {
     encode(args: ICodeArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: ICodeArgs = {
             status: (typeof args.status === "number" ? new thrift.Int64(args.status) : typeof args.status === "string" ? thrift.Int64.fromDecimalString(args.status) : args.status)
         };
         output.writeStructBegin("Code");

--- a/src/tests/unit/fixtures/thrift-server/generated/SharedService.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/SharedService.ts
@@ -40,7 +40,7 @@ export interface IGetUnion__ArgsArgs {
 }
 export const GetUnion__ArgsCodec: thrift.IStructCodec<IGetUnion__ArgsArgs, IGetUnion__Args> = {
     encode(args: IGetUnion__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IGetUnion__ArgsArgs = {
             index: args.index
         };
         output.writeStructBegin("GetUnion__Args");
@@ -179,7 +179,7 @@ export interface IGetUnion__ResultArgs {
 }
 export const GetUnion__ResultCodec: thrift.IStructCodec<IGetUnion__ResultArgs, IGetUnion__Result> = {
     encode(args: IGetUnion__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IGetUnion__ResultArgs = {
             success: args.success
         };
         output.writeStructBegin("GetUnion__Result");
@@ -256,7 +256,7 @@ export interface IGetEnum__ResultArgs {
 }
 export const GetEnum__ResultCodec: thrift.IStructCodec<IGetEnum__ResultArgs, IGetEnum__Result> = {
     encode(args: IGetEnum__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IGetEnum__ResultArgs = {
             success: args.success
         };
         output.writeStructBegin("GetEnum__Result");

--- a/src/tests/unit/fixtures/thrift-server/generated/SharedServiceBase.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/SharedServiceBase.ts
@@ -28,7 +28,7 @@ export interface IGetStruct__ArgsArgs {
 }
 export const GetStruct__ArgsCodec: thrift.IStructCodec<IGetStruct__ArgsArgs, IGetStruct__Args> = {
     encode(args: IGetStruct__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IGetStruct__ArgsArgs = {
             key: args.key
         };
         output.writeStructBegin("GetStruct__Args");
@@ -116,7 +116,7 @@ export interface IGetStruct__ResultArgs {
 }
 export const GetStruct__ResultCodec: thrift.IStructCodec<IGetStruct__ResultArgs, IGetStruct__Result> = {
     encode(args: IGetStruct__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IGetStruct__ResultArgs = {
             success: args.success
         };
         output.writeStructBegin("GetStruct__Result");

--- a/src/tests/unit/fixtures/thrift-server/generated/SharedStruct.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/SharedStruct.ts
@@ -9,16 +9,19 @@ export interface ISharedStruct {
     __name: "SharedStruct";
     code: Code.ICode;
     value: string;
+    mapWithDefault?: Map<string, string>;
 }
 export interface ISharedStructArgs {
     code: Code.ICodeArgs;
     value: string;
+    mapWithDefault?: Map<string, string>;
 }
 export const SharedStructCodec: thrift.IStructCodec<ISharedStructArgs, ISharedStruct> = {
     encode(args: ISharedStructArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: ISharedStructArgs = {
             code: args.code,
-            value: args.value
+            value: args.value,
+            mapWithDefault: (args.mapWithDefault != null ? args.mapWithDefault : new Map([]))
         };
         output.writeStructBegin("SharedStruct");
         if (obj.code != null) {
@@ -37,6 +40,16 @@ export const SharedStructCodec: thrift.IStructCodec<ISharedStructArgs, ISharedSt
         else {
             throw new thrift.TProtocolException(thrift.TProtocolExceptionType.UNKNOWN, "Required field[value] is unset!");
         }
+        if (obj.mapWithDefault != null) {
+            output.writeFieldBegin("mapWithDefault", thrift.TType.MAP, 3);
+            output.writeMapBegin(thrift.TType.STRING, thrift.TType.STRING, obj.mapWithDefault.size);
+            obj.mapWithDefault.forEach((value_1: string, key_1: string): void => {
+                output.writeString(key_1);
+                output.writeString(value_1);
+            });
+            output.writeMapEnd();
+            output.writeFieldEnd();
+        }
         output.writeFieldStop();
         output.writeStructEnd();
         return;
@@ -54,8 +67,8 @@ export const SharedStructCodec: thrift.IStructCodec<ISharedStructArgs, ISharedSt
             switch (fieldId) {
                 case 1:
                     if (fieldType === thrift.TType.STRUCT) {
-                        const value_1: Code.ICode = Code.CodeCodec.decode(input);
-                        _args.code = value_1;
+                        const value_2: Code.ICode = Code.CodeCodec.decode(input);
+                        _args.code = value_2;
                     }
                     else {
                         input.skip(fieldType);
@@ -63,8 +76,25 @@ export const SharedStructCodec: thrift.IStructCodec<ISharedStructArgs, ISharedSt
                     break;
                 case 2:
                     if (fieldType === thrift.TType.STRING) {
-                        const value_2: string = input.readString();
-                        _args.value = value_2;
+                        const value_3: string = input.readString();
+                        _args.value = value_3;
+                    }
+                    else {
+                        input.skip(fieldType);
+                    }
+                    break;
+                case 3:
+                    if (fieldType === thrift.TType.MAP) {
+                        const value_4: Map<string, string> = new Map<string, string>();
+                        const metadata_1: thrift.IThriftMap = input.readMapBegin();
+                        const size_1: number = metadata_1.size;
+                        for (let i_1: number = 0; i_1 < size_1; i_1++) {
+                            const key_2: string = input.readString();
+                            const value_5: string = input.readString();
+                            value_4.set(key_2, value_5);
+                        }
+                        input.readMapEnd();
+                        _args.mapWithDefault = value_4;
                     }
                     else {
                         input.skip(fieldType);
@@ -81,7 +111,8 @@ export const SharedStructCodec: thrift.IStructCodec<ISharedStructArgs, ISharedSt
             return {
                 __name: "SharedStruct",
                 code: _args.code,
-                value: _args.value
+                value: _args.value,
+                mapWithDefault: (_args.mapWithDefault != null ? _args.mapWithDefault : new Map([]))
             };
         }
         else {
@@ -92,24 +123,34 @@ export const SharedStructCodec: thrift.IStructCodec<ISharedStructArgs, ISharedSt
 export class SharedStruct extends thrift.StructLike implements ISharedStruct {
     public code: Code.ICode;
     public value: string;
+    public mapWithDefault?: Map<string, string> = new Map([]);
     public readonly __name = "SharedStruct";
     public readonly _annotations: thrift.IThriftAnnotations = {};
     public readonly _fieldAnnotations: thrift.IFieldAnnotations = {};
     constructor(args: ISharedStructArgs) {
         super();
         if (args.code != null) {
-            const value_3: Code.ICode = new Code.Code(args.code);
-            this.code = value_3;
+            const value_6: Code.ICode = new Code.Code(args.code);
+            this.code = value_6;
         }
         else {
             throw new thrift.TProtocolException(thrift.TProtocolExceptionType.UNKNOWN, "Required field[code] is unset!");
         }
         if (args.value != null) {
-            const value_4: string = args.value;
-            this.value = value_4;
+            const value_7: string = args.value;
+            this.value = value_7;
         }
         else {
             throw new thrift.TProtocolException(thrift.TProtocolExceptionType.UNKNOWN, "Required field[value] is unset!");
+        }
+        if (args.mapWithDefault != null) {
+            const value_8: Map<string, string> = new Map<string, string>();
+            args.mapWithDefault.forEach((value_9: string, key_3: string): void => {
+                const value_10: string = value_9;
+                const key_4: string = key_3;
+                value_8.set(key_4, value_10);
+            });
+            this.mapWithDefault = value_8;
         }
     }
     public static read(input: thrift.TProtocol): SharedStruct {

--- a/src/tests/unit/fixtures/thrift-server/generated/SharedUnion.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/SharedUnion.ts
@@ -16,7 +16,7 @@ export interface ISharedUnionArgs {
 export const SharedUnionCodec: thrift.IStructCodec<ISharedUnionArgs, ISharedUnion> = {
     encode(args: ISharedUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj = {
+        const obj: ISharedUnionArgs = {
             option1: args.option1,
             option2: args.option2
         };

--- a/src/tests/unit/fixtures/thrift-server/generated/com/test/calculator/Calculator.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/com/test/calculator/Calculator.ts
@@ -173,7 +173,7 @@ export interface IAdd__ArgsArgs {
 }
 export const Add__ArgsCodec: thrift.IStructCodec<IAdd__ArgsArgs, IAdd__Args> = {
     encode(args: IAdd__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IAdd__ArgsArgs = {
             num1: args.num1,
             num2: args.num2
         };
@@ -290,7 +290,7 @@ export interface IAddInt64__ArgsArgs {
 }
 export const AddInt64__ArgsCodec: thrift.IStructCodec<IAddInt64__ArgsArgs, IAddInt64__Args> = {
     encode(args: IAddInt64__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IAddInt64__ArgsArgs = {
             num1: (typeof args.num1 === "number" ? new thrift.Int64(args.num1) : typeof args.num1 === "string" ? thrift.Int64.fromDecimalString(args.num1) : args.num1),
             num2: (typeof args.num2 === "number" ? new thrift.Int64(args.num2) : typeof args.num2 === "string" ? thrift.Int64.fromDecimalString(args.num2) : args.num2)
         };
@@ -407,7 +407,7 @@ export interface IAddWithContext__ArgsArgs {
 }
 export const AddWithContext__ArgsCodec: thrift.IStructCodec<IAddWithContext__ArgsArgs, IAddWithContext__Args> = {
     encode(args: IAddWithContext__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IAddWithContext__ArgsArgs = {
             num1: args.num1,
             num2: args.num2
         };
@@ -524,7 +524,7 @@ export interface ICalculate__ArgsArgs {
 }
 export const Calculate__ArgsCodec: thrift.IStructCodec<ICalculate__ArgsArgs, ICalculate__Args> = {
     encode(args: ICalculate__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: ICalculate__ArgsArgs = {
             logid: args.logid,
             work: args.work
         };
@@ -639,7 +639,7 @@ export interface IEchoBinary__ArgsArgs {
 }
 export const EchoBinary__ArgsCodec: thrift.IStructCodec<IEchoBinary__ArgsArgs, IEchoBinary__Args> = {
     encode(args: IEchoBinary__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IEchoBinary__ArgsArgs = {
             word: (typeof args.word === "string" ? Buffer.from(args.word) : args.word)
         };
         output.writeStructBegin("EchoBinary__Args");
@@ -727,7 +727,7 @@ export interface IEchoString__ArgsArgs {
 }
 export const EchoString__ArgsCodec: thrift.IStructCodec<IEchoString__ArgsArgs, IEchoString__Args> = {
     encode(args: IEchoString__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IEchoString__ArgsArgs = {
             word: args.word
         };
         output.writeStructBegin("EchoString__Args");
@@ -815,7 +815,7 @@ export interface ICheckName__ArgsArgs {
 }
 export const CheckName__ArgsCodec: thrift.IStructCodec<ICheckName__ArgsArgs, ICheckName__Args> = {
     encode(args: ICheckName__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: ICheckName__ArgsArgs = {
             choice: args.choice
         };
         output.writeStructBegin("CheckName__Args");
@@ -903,7 +903,7 @@ export interface ICheckOptional__ArgsArgs {
 }
 export const CheckOptional__ArgsCodec: thrift.IStructCodec<ICheckOptional__ArgsArgs, ICheckOptional__Args> = {
     encode(args: ICheckOptional__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: ICheckOptional__ArgsArgs = {
             type: args.type
         };
         output.writeStructBegin("CheckOptional__Args");
@@ -980,7 +980,7 @@ export interface IMapOneList__ArgsArgs {
 }
 export const MapOneList__ArgsCodec: thrift.IStructCodec<IMapOneList__ArgsArgs, IMapOneList__Args> = {
     encode(args: IMapOneList__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IMapOneList__ArgsArgs = {
             arg: args.arg
         };
         output.writeStructBegin("MapOneList__Args");
@@ -1083,7 +1083,7 @@ export interface IMapValues__ArgsArgs {
 }
 export const MapValues__ArgsCodec: thrift.IStructCodec<IMapValues__ArgsArgs, IMapValues__Args> = {
     encode(args: IMapValues__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IMapValues__ArgsArgs = {
             arg: args.arg
         };
         output.writeStructBegin("MapValues__Args");
@@ -1189,7 +1189,7 @@ export interface IListToMap__ArgsArgs {
 }
 export const ListToMap__ArgsCodec: thrift.IStructCodec<IListToMap__ArgsArgs, IListToMap__Args> = {
     encode(args: IListToMap__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IListToMap__ArgsArgs = {
             arg: args.arg
         };
         output.writeStructBegin("ListToMap__Args");
@@ -1530,7 +1530,7 @@ export interface IAdd__ResultArgs {
 }
 export const Add__ResultCodec: thrift.IStructCodec<IAdd__ResultArgs, IAdd__Result> = {
     encode(args: IAdd__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IAdd__ResultArgs = {
             success: args.success,
             exp: args.exp
         };
@@ -1630,7 +1630,7 @@ export interface IAddInt64__ResultArgs {
 }
 export const AddInt64__ResultCodec: thrift.IStructCodec<IAddInt64__ResultArgs, IAddInt64__Result> = {
     encode(args: IAddInt64__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IAddInt64__ResultArgs = {
             success: (typeof args.success === "number" ? new thrift.Int64(args.success) : typeof args.success === "string" ? thrift.Int64.fromDecimalString(args.success) : args.success),
             exp: args.exp
         };
@@ -1728,7 +1728,7 @@ export interface IAddWithContext__ResultArgs {
 }
 export const AddWithContext__ResultCodec: thrift.IStructCodec<IAddWithContext__ResultArgs, IAddWithContext__Result> = {
     encode(args: IAddWithContext__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IAddWithContext__ResultArgs = {
             success: args.success
         };
         output.writeStructBegin("AddWithContext__Result");
@@ -1807,7 +1807,7 @@ export interface ICalculate__ResultArgs {
 }
 export const Calculate__ResultCodec: thrift.IStructCodec<ICalculate__ResultArgs, ICalculate__Result> = {
     encode(args: ICalculate__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: ICalculate__ResultArgs = {
             success: args.success,
             ouch: args.ouch
         };
@@ -1905,7 +1905,7 @@ export interface IEchoBinary__ResultArgs {
 }
 export const EchoBinary__ResultCodec: thrift.IStructCodec<IEchoBinary__ResultArgs, IEchoBinary__Result> = {
     encode(args: IEchoBinary__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IEchoBinary__ResultArgs = {
             success: args.success
         };
         output.writeStructBegin("EchoBinary__Result");
@@ -1982,7 +1982,7 @@ export interface IEchoString__ResultArgs {
 }
 export const EchoString__ResultCodec: thrift.IStructCodec<IEchoString__ResultArgs, IEchoString__Result> = {
     encode(args: IEchoString__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IEchoString__ResultArgs = {
             success: args.success
         };
         output.writeStructBegin("EchoString__Result");
@@ -2059,7 +2059,7 @@ export interface ICheckName__ResultArgs {
 }
 export const CheckName__ResultCodec: thrift.IStructCodec<ICheckName__ResultArgs, ICheckName__Result> = {
     encode(args: ICheckName__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: ICheckName__ResultArgs = {
             success: args.success
         };
         output.writeStructBegin("CheckName__Result");
@@ -2136,7 +2136,7 @@ export interface ICheckOptional__ResultArgs {
 }
 export const CheckOptional__ResultCodec: thrift.IStructCodec<ICheckOptional__ResultArgs, ICheckOptional__Result> = {
     encode(args: ICheckOptional__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: ICheckOptional__ResultArgs = {
             success: args.success
         };
         output.writeStructBegin("CheckOptional__Result");
@@ -2213,7 +2213,7 @@ export interface IMapOneList__ResultArgs {
 }
 export const MapOneList__ResultCodec: thrift.IStructCodec<IMapOneList__ResultArgs, IMapOneList__Result> = {
     encode(args: IMapOneList__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IMapOneList__ResultArgs = {
             success: args.success
         };
         output.writeStructBegin("MapOneList__Result");
@@ -2305,7 +2305,7 @@ export interface IMapValues__ResultArgs {
 }
 export const MapValues__ResultCodec: thrift.IStructCodec<IMapValues__ResultArgs, IMapValues__Result> = {
     encode(args: IMapValues__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IMapValues__ResultArgs = {
             success: args.success
         };
         output.writeStructBegin("MapValues__Result");
@@ -2397,7 +2397,7 @@ export interface IListToMap__ResultArgs {
 }
 export const ListToMap__ResultCodec: thrift.IStructCodec<IListToMap__ResultArgs, IListToMap__Result> = {
     encode(args: IListToMap__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IListToMap__ResultArgs = {
             success: args.success
         };
         output.writeStructBegin("ListToMap__Result");
@@ -2492,7 +2492,7 @@ export interface IFetchThing__ResultArgs {
 }
 export const FetchThing__ResultCodec: thrift.IStructCodec<IFetchThing__ResultArgs, IFetchThing__Result> = {
     encode(args: IFetchThing__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IFetchThing__ResultArgs = {
             success: args.success
         };
         output.writeStructBegin("FetchThing__Result");
@@ -2569,7 +2569,7 @@ export interface IFetchMap__ResultArgs {
 }
 export const FetchMap__ResultCodec: thrift.IStructCodec<IFetchMap__ResultArgs, IFetchMap__Result> = {
     encode(args: IFetchMap__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IFetchMap__ResultArgs = {
             success: args.success
         };
         output.writeStructBegin("FetchMap__Result");

--- a/src/tests/unit/fixtures/thrift-server/generated/com/test/calculator/Choice.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/com/test/calculator/Choice.ts
@@ -18,7 +18,7 @@ export interface IChoiceArgs {
 export const ChoiceCodec: thrift.IStructCodec<IChoiceArgs, IChoice> = {
     encode(args: IChoiceArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj = {
+        const obj: IChoiceArgs = {
             firstName: args.firstName,
             lastName: args.lastName
         };

--- a/src/tests/unit/fixtures/thrift-server/generated/com/test/calculator/FirstName.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/com/test/calculator/FirstName.ts
@@ -13,7 +13,7 @@ export interface IFirstNameArgs {
 }
 export const FirstNameCodec: thrift.IStructCodec<IFirstNameArgs, IFirstName> = {
     encode(args: IFirstNameArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IFirstNameArgs = {
             name: args.name
         };
         output.writeStructBegin("FirstName");

--- a/src/tests/unit/fixtures/thrift-server/generated/com/test/calculator/LastName.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/com/test/calculator/LastName.ts
@@ -13,7 +13,7 @@ export interface ILastNameArgs {
 }
 export const LastNameCodec: thrift.IStructCodec<ILastNameArgs, ILastName> = {
     encode(args: ILastNameArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: ILastNameArgs = {
             name: args.name
         };
         output.writeStructBegin("LastName");

--- a/src/tests/unit/fixtures/thrift-server/generated/com/test/calculator/NotAGoodIdea.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/com/test/calculator/NotAGoodIdea.ts
@@ -17,7 +17,7 @@ export interface INotAGoodIdeaArgs {
 }
 export const NotAGoodIdeaCodec: thrift.IStructCodec<INotAGoodIdeaArgs, INotAGoodIdea> = {
     encode(args: INotAGoodIdeaArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: INotAGoodIdeaArgs = {
             message: args.message,
             data: args.data
         };

--- a/src/tests/unit/fixtures/thrift-server/generated/com/test/calculator/Work.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/com/test/calculator/Work.ts
@@ -20,7 +20,7 @@ export interface IWorkArgs {
 }
 export const WorkCodec: thrift.IStructCodec<IWorkArgs, IWork> = {
     encode(args: IWorkArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IWorkArgs = {
             num1: (args.num1 != null ? args.num1 : 0),
             num2: args.num2,
             op: (args.op != null ? args.op : Operation.Operation.ADD),

--- a/src/tests/unit/fixtures/thrift-server/generated/com/test/common/AuthException.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/com/test/common/AuthException.ts
@@ -15,7 +15,7 @@ export interface IAuthExceptionArgs {
 }
 export const AuthExceptionCodec: thrift.IStructCodec<IAuthExceptionArgs, IAuthException> = {
     encode(args: IAuthExceptionArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IAuthExceptionArgs = {
             code: args.code,
             message: args.message
         };

--- a/src/tests/unit/fixtures/thrift-server/generated/com/test/common/OtherCommonUnion.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/com/test/common/OtherCommonUnion.ts
@@ -16,7 +16,7 @@ export interface IOtherCommonUnionArgs {
 export const OtherCommonUnionCodec: thrift.IStructCodec<IOtherCommonUnionArgs, IOtherCommonUnion> = {
     encode(args: IOtherCommonUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj = {
+        const obj: IOtherCommonUnionArgs = {
             option1: args.option1,
             option2: args.option2
         };

--- a/src/tests/unit/fixtures/thrift-server/generated/com/test/exceptions/InvalidOperation.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/com/test/exceptions/InvalidOperation.ts
@@ -15,7 +15,7 @@ export interface IInvalidOperationArgs {
 }
 export const InvalidOperationCodec: thrift.IStructCodec<IInvalidOperationArgs, IInvalidOperation> = {
     encode(args: IInvalidOperationArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IInvalidOperationArgs = {
             whatOp: args.whatOp,
             why: args.why
         };

--- a/src/tests/unit/fixtures/thrift-server/generated/com/test/exceptions/InvalidResult.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/com/test/exceptions/InvalidResult.ts
@@ -16,7 +16,7 @@ export interface IInvalidResultArgs {
 }
 export const InvalidResultCodec: thrift.IStructCodec<IInvalidResultArgs, IInvalidResult> = {
     encode(args: IInvalidResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IInvalidResultArgs = {
             message: args.message,
             code: args.code
         };

--- a/src/tests/unit/fixtures/thrift-server/i64_service.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/i64_service.solution.ts
@@ -7,7 +7,7 @@ export interface ICodeArgs {
 }
 export const CodeCodec: thrift.IStructCodec<ICodeArgs, ICode> = {
     encode(args: ICodeArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: ICodeArgs = {
             status: (typeof args.status === "number" ? new thrift.Int64(args.status) : typeof args.status === "string" ? thrift.Int64.fromDecimalString(args.status) : args.status)
         };
         output.writeStructBegin("Code");
@@ -103,7 +103,7 @@ export interface IPeg__ArgsArgs {
 }
 export const Peg__ArgsCodec: thrift.IStructCodec<IPeg__ArgsArgs, IPeg__Args> = {
     encode(args: IPeg__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IPeg__ArgsArgs = {
             name: args.name
         };
         output.writeStructBegin("Peg__Args");
@@ -191,7 +191,7 @@ export interface IPong__ArgsArgs {
 }
 export const Pong__ArgsCodec: thrift.IStructCodec<IPong__ArgsArgs, IPong__Args> = {
     encode(args: IPong__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IPong__ArgsArgs = {
             code: args.code
         };
         output.writeStructBegin("Pong__Args");
@@ -268,7 +268,7 @@ export interface IPeg__ResultArgs {
 }
 export const Peg__ResultCodec: thrift.IStructCodec<IPeg__ResultArgs, IPeg__Result> = {
     encode(args: IPeg__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IPeg__ResultArgs = {
             success: args.success
         };
         output.writeStructBegin("Peg__Result");
@@ -345,7 +345,7 @@ export interface IPong__ResultArgs {
 }
 export const Pong__ResultCodec: thrift.IStructCodec<IPong__ResultArgs, IPong__Result> = {
     encode(args: IPong__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IPong__ResultArgs = {
             success: (typeof args.success === "number" ? new thrift.Int64(args.success) : typeof args.success === "string" ? thrift.Int64.fromDecimalString(args.success) : args.success)
         };
         output.writeStructBegin("Pong__Result");

--- a/src/tests/unit/fixtures/thrift-server/initialized_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/initialized_union.solution.ts
@@ -9,7 +9,7 @@ export interface IMyUnionArgs {
 export const MyUnionCodec: thrift.IStructCodec<IMyUnionArgs, IMyUnion> = {
     encode(args: IMyUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj = {
+        const obj: IMyUnionArgs = {
             option1: args.option1,
             option2: (typeof args.option2 === "number" ? new thrift.Int64(args.option2) : typeof args.option2 === "string" ? thrift.Int64.fromDecimalString(args.option2) : args.option2)
         };

--- a/src/tests/unit/fixtures/thrift-server/initialized_union.strict_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/initialized_union.strict_union.solution.ts
@@ -66,7 +66,7 @@ export const MyUnionCodec: thrift.IStructToolkit<MyUnionArgs, MyUnion> = {
     },
     encode(args: MyUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj = {
+        const obj: MyUnionArgs = {
             field1: args.field1,
             field2: (typeof args.field2 === "number" ? new thrift.Int64(args.field2) : typeof args.field2 === "string" ? thrift.Int64.fromDecimalString(args.field2) : args.field2)
         };

--- a/src/tests/unit/fixtures/thrift-server/multi_field_struct.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/multi_field_struct.solution.ts
@@ -15,7 +15,7 @@ export interface IMyStructArgs {
 }
 export const MyStructCodec: thrift.IStructCodec<IMyStructArgs, IMyStruct> = {
     encode(args: IMyStructArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IMyStructArgs = {
             id: (args.id != null ? args.id : 45),
             bigID: (args.bigID != null ? (typeof args.bigID === "number" ? new thrift.Int64(args.bigID) : typeof args.bigID === "string" ? thrift.Int64.fromDecimalString(args.bigID) : args.bigID) : thrift.Int64.fromDecimalString("23948234")),
             word: args.word,

--- a/src/tests/unit/fixtures/thrift-server/nested_exception.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/nested_exception.solution.ts
@@ -9,7 +9,7 @@ export interface ICodeArgs {
 }
 export const CodeCodec: thrift.IStructCodec<ICodeArgs, ICode> = {
     encode(args: ICodeArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: ICodeArgs = {
             status: (args.status != null ? (typeof args.status === "number" ? new thrift.Int64(args.status) : typeof args.status === "string" ? thrift.Int64.fromDecimalString(args.status) : args.status) : thrift.Int64.fromDecimalString("200")),
             data: (args.data != null ? (typeof args.data === "string" ? Buffer.from(args.data) : args.data) : Buffer.from("data"))
         };
@@ -109,7 +109,7 @@ export interface IMyExceptionArgs {
 }
 export const MyExceptionCodec: thrift.IStructCodec<IMyExceptionArgs, IMyException> = {
     encode(args: IMyExceptionArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IMyExceptionArgs = {
             description: args.description,
             code: args.code
         };

--- a/src/tests/unit/fixtures/thrift-server/nested_struct.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/nested_struct.solution.ts
@@ -9,7 +9,7 @@ export interface IUserArgs {
 }
 export const UserCodec: thrift.IStructCodec<IUserArgs, IUser> = {
     encode(args: IUserArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IUserArgs = {
             name: args.name,
             age: (args.age != null ? (typeof args.age === "number" ? new thrift.Int64(args.age) : typeof args.age === "string" ? thrift.Int64.fromDecimalString(args.age) : args.age) : thrift.Int64.fromDecimalString("45"))
         };
@@ -120,7 +120,7 @@ export interface IMyStructArgs {
 }
 export const MyStructCodec: thrift.IStructCodec<IMyStructArgs, IMyStruct> = {
     encode(args: IMyStructArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IMyStructArgs = {
             name: args.name,
             user: args.user
         };

--- a/src/tests/unit/fixtures/thrift-server/nested_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/nested_union.solution.ts
@@ -10,7 +10,7 @@ export interface IOptionArgs {
 export const OptionCodec: thrift.IStructCodec<IOptionArgs, IOption> = {
     encode(args: IOptionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj = {
+        const obj: IOptionArgs = {
             option1: (typeof args.option1 === "string" ? Buffer.from(args.option1) : args.option1),
             option2: (typeof args.option2 === "number" ? new thrift.Int64(args.option2) : typeof args.option2 === "string" ? thrift.Int64.fromDecimalString(args.option2) : args.option2)
         };
@@ -149,7 +149,7 @@ export interface IMyUnionArgs {
 export const MyUnionCodec: thrift.IStructCodec<IMyUnionArgs, IMyUnion> = {
     encode(args: IMyUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj = {
+        const obj: IMyUnionArgs = {
             name: args.name,
             option: args.option
         };

--- a/src/tests/unit/fixtures/thrift-server/nested_union.strict_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/nested_union.strict_union.solution.ts
@@ -66,7 +66,7 @@ export const InnerUnionCodec: thrift.IStructToolkit<InnerUnionArgs, InnerUnion> 
     },
     encode(args: InnerUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj = {
+        const obj: InnerUnionArgs = {
             name: args.name,
             id: args.id
         };
@@ -227,7 +227,7 @@ export const MyUnionCodec: thrift.IStructToolkit<MyUnionArgs, MyUnion> = {
     },
     encode(args: MyUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj = {
+        const obj: MyUnionArgs = {
             user: args.user,
             field2: args.field2
         };

--- a/src/tests/unit/fixtures/thrift-server/required_field_exception.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/required_field_exception.solution.ts
@@ -9,7 +9,7 @@ export interface IMyExceptionArgs {
 }
 export const MyExceptionCodec: thrift.IStructCodec<IMyExceptionArgs, IMyException> = {
     encode(args: IMyExceptionArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IMyExceptionArgs = {
             description: args.description,
             code: args.code
         };

--- a/src/tests/unit/fixtures/thrift-server/resolved_field_service.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/resolved_field_service.solution.ts
@@ -22,7 +22,7 @@ export interface IPing__ArgsArgs {
 }
 export const Ping__ArgsCodec: thrift.IStructCodec<IPing__ArgsArgs, IPing__Args> = {
     encode(args: IPing__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IPing__ArgsArgs = {
             id: (typeof args.id === "number" ? new thrift.Int64(args.id) : typeof args.id === "string" ? thrift.Int64.fromDecimalString(args.id) : args.id)
         };
         output.writeStructBegin("Ping__Args");

--- a/src/tests/unit/fixtures/thrift-server/throws_multi_service.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/throws_multi_service.solution.ts
@@ -7,7 +7,7 @@ export interface IServiceExceptionArgs {
 }
 export const ServiceExceptionCodec: thrift.IStructCodec<IServiceExceptionArgs, IServiceException> = {
     encode(args: IServiceExceptionArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IServiceExceptionArgs = {
             message: args.message
         };
         output.writeStructBegin("ServiceException");
@@ -86,7 +86,7 @@ export interface IAuthExceptionArgs {
 }
 export const AuthExceptionCodec: thrift.IStructCodec<IAuthExceptionArgs, IAuthException> = {
     encode(args: IAuthExceptionArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IAuthExceptionArgs = {
             message: args.message,
             code: args.code
         };
@@ -184,7 +184,7 @@ export interface IUnknownExceptionArgs {
 }
 export const UnknownExceptionCodec: thrift.IStructCodec<IUnknownExceptionArgs, IUnknownException> = {
     encode(args: IUnknownExceptionArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IUnknownExceptionArgs = {
             message: args.message
         };
         output.writeStructBegin("UnknownException");
@@ -275,7 +275,7 @@ export interface IPeg__ArgsArgs {
 }
 export const Peg__ArgsCodec: thrift.IStructCodec<IPeg__ArgsArgs, IPeg__Args> = {
     encode(args: IPeg__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IPeg__ArgsArgs = {
             name: args.name
         };
         output.writeStructBegin("Peg__Args");
@@ -369,7 +369,7 @@ export interface IPeg__ResultArgs {
 }
 export const Peg__ResultCodec: thrift.IStructCodec<IPeg__ResultArgs, IPeg__Result> = {
     encode(args: IPeg__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IPeg__ResultArgs = {
             success: args.success,
             exp: args.exp,
             authExp: args.authExp,

--- a/src/tests/unit/fixtures/thrift-server/throws_service.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/throws_service.solution.ts
@@ -7,7 +7,7 @@ export interface IServiceExceptionArgs {
 }
 export const ServiceExceptionCodec: thrift.IStructCodec<IServiceExceptionArgs, IServiceException> = {
     encode(args: IServiceExceptionArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IServiceExceptionArgs = {
             message: args.message
         };
         output.writeStructBegin("ServiceException");
@@ -103,7 +103,7 @@ export interface IPeg__ArgsArgs {
 }
 export const Peg__ArgsCodec: thrift.IStructCodec<IPeg__ArgsArgs, IPeg__Args> = {
     encode(args: IPeg__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IPeg__ArgsArgs = {
             name: args.name
         };
         output.writeStructBegin("Peg__Args");
@@ -191,7 +191,7 @@ export interface IPong__ArgsArgs {
 }
 export const Pong__ArgsCodec: thrift.IStructCodec<IPong__ArgsArgs, IPong__Args> = {
     encode(args: IPong__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IPong__ArgsArgs = {
             name: args.name
         };
         output.writeStructBegin("Pong__Args");
@@ -270,7 +270,7 @@ export interface IPeg__ResultArgs {
 }
 export const Peg__ResultCodec: thrift.IStructCodec<IPeg__ResultArgs, IPeg__Result> = {
     encode(args: IPeg__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IPeg__ResultArgs = {
             success: args.success,
             exp: args.exp
         };
@@ -368,7 +368,7 @@ export interface IPong__ResultArgs {
 }
 export const Pong__ResultCodec: thrift.IStructCodec<IPong__ResultArgs, IPong__Result> = {
     encode(args: IPong__ResultArgs, output: thrift.TProtocol): void {
-        const obj = {
+        const obj: IPong__ResultArgs = {
             success: args.success
         };
         output.writeStructBegin("Pong__Result");

--- a/src/tests/unit/fixtures/thrift/shared.thrift
+++ b/src/tests/unit/fixtures/thrift/shared.thrift
@@ -7,6 +7,7 @@ struct Code {
 struct SharedStruct {
   1: required Code code
   2: required string value
+  3: optional map<string, string> mapWithDefault = {}
 }
 
 union SharedUnion {


### PR DESCRIPTION
There is a type error that occurs in the encode method for structs and unions with an empty map initializer.  The temporary object sees the default map as `Map<unknown, unknown>`.

before:
<img width="588" alt="Screen Shot 2019-07-01 at 1 28 39 PM" src="https://user-images.githubusercontent.com/816527/60466668-228fd100-9c09-11e9-9abb-31ce3b9e8a99.png">
after:
<img width="611" alt="Screen Shot 2019-07-01 at 2 05 55 PM" src="https://user-images.githubusercontent.com/816527/60466753-68e53000-9c09-11e9-9aae-3b74e9f3e324.png">

I think this may only be an issue with specific flags or typescript versions, but adding the explicit type avoids any issues. 
