### PR TITLE
fix: update how type for temp object in encode is defined to fix strict unions

### DIFF
--- a/src/main/render/thrift-server/struct/encode.ts
+++ b/src/main/render/thrift-server/struct/encode.ts
@@ -54,28 +54,31 @@ export function createTempVariables(
         return [
             createConstStatement(
                 COMMON_IDENTIFIERS.obj,
-                ts.createTypeReferenceNode(
-                    ts.createIdentifier(looseNameForStruct(node, state)),
-                    undefined,
-                ),
-                ts.createObjectLiteral(
-                    node.fields.map(
-                        (
-                            next: FieldDefinition,
-                        ): ts.ObjectLiteralElementLike => {
-                            return ts.createPropertyAssignment(
-                                next.name.value,
-                                getInitializerForField(
-                                    COMMON_IDENTIFIERS.args,
-                                    next,
-                                    state,
-                                    withDefault,
-                                    true,
-                                ),
-                            )
-                        },
+                undefined,
+                ts.createAsExpression(
+                    ts.createObjectLiteral(
+                        node.fields.map(
+                            (
+                                next: FieldDefinition,
+                            ): ts.ObjectLiteralElementLike => {
+                                return ts.createPropertyAssignment(
+                                    next.name.value,
+                                    getInitializerForField(
+                                        COMMON_IDENTIFIERS.args,
+                                        next,
+                                        state,
+                                        withDefault,
+                                        true,
+                                    ),
+                                )
+                            },
+                        ),
+                        true, // multiline
                     ),
-                    true, // multiline
+                    ts.createTypeReferenceNode(
+                        ts.createIdentifier(looseNameForStruct(node, state)),
+                        undefined,
+                    ),
                 ),
             ),
         ]

--- a/src/main/render/thrift-server/struct/encode.ts
+++ b/src/main/render/thrift-server/struct/encode.ts
@@ -37,6 +37,7 @@ import {
 
 import { DefinitionType, IRenderState } from '../../../types'
 
+import { createLetStatement } from '../../shared/utils'
 import { looseNameForStruct, throwForField, toolkitName } from './utils'
 
 export function createTempVariables(
@@ -50,9 +51,14 @@ export function createTempVariables(
         },
     )
 
+    // Unions use reassignment for defaults
+    const createVariable = withDefault
+        ? createConstStatement
+        : createLetStatement
+
     if (structFields.length > 0) {
         return [
-            createConstStatement(
+            createVariable(
                 COMMON_IDENTIFIERS.obj,
                 undefined,
                 ts.createAsExpression(

--- a/src/main/render/thrift-server/union/encode.ts
+++ b/src/main/render/thrift-server/union/encode.ts
@@ -124,17 +124,19 @@ function checkDefaults(
                     [
                         ts.createStatement(
                             ts.createAssignment(
-                                ts.createPropertyAccess(
-                                    COMMON_IDENTIFIERS.obj,
-                                    ts.createIdentifier(
-                                        defaultField.name.value,
+                                COMMON_IDENTIFIERS.obj,
+                                ts.createObjectLiteral([
+                                    ts.createPropertyAssignment(
+                                        ts.createIdentifier(
+                                            defaultField.name.value,
+                                        ),
+                                        renderValue(
+                                            defaultField.fieldType,
+                                            defaultField.defaultValue!,
+                                            state,
+                                        ),
                                     ),
-                                ),
-                                renderValue(
-                                    defaultField.fieldType,
-                                    defaultField.defaultValue!,
-                                    state,
-                                ),
+                                ]),
                             ),
                         ),
                     ],

--- a/src/tests/unit/fixtures/thrift-server/annotations_exception.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/annotations_exception.solution.ts
@@ -9,10 +9,10 @@ export interface IMyExceptionArgs {
 }
 export const MyExceptionCodec: thrift.IStructCodec<IMyExceptionArgs, IMyException> = {
     encode(args: IMyExceptionArgs, output: thrift.TProtocol): void {
-        const obj: IMyExceptionArgs = {
+        const obj = ({
             message: args.message,
             code: (args.code != null ? args.code : 200)
-        };
+        } as IMyExceptionArgs);
         output.writeStructBegin("MyException");
         if (obj.message != null) {
             output.writeFieldBegin("message", thrift.TType.STRING, 1);

--- a/src/tests/unit/fixtures/thrift-server/annotations_service.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/annotations_service.solution.ts
@@ -9,10 +9,10 @@ export interface IUserArgs {
 }
 export const UserCodec: thrift.IStructCodec<IUserArgs, IUser> = {
     encode(args: IUserArgs, output: thrift.TProtocol): void {
-        const obj: IUserArgs = {
+        const obj = ({
             name: args.name,
             id: args.id
-        };
+        } as IUserArgs);
         output.writeStructBegin("User");
         if (obj.name != null) {
             output.writeFieldBegin("name", thrift.TType.STRING, 1);
@@ -160,9 +160,9 @@ export interface IGetUser__ArgsArgs {
 }
 export const GetUser__ArgsCodec: thrift.IStructCodec<IGetUser__ArgsArgs, IGetUser__Args> = {
     encode(args: IGetUser__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: IGetUser__ArgsArgs = {
+        const obj = ({
             id: args.id
-        };
+        } as IGetUser__ArgsArgs);
         output.writeStructBegin("GetUser__Args");
         if (obj.id != null) {
             output.writeFieldBegin("id", thrift.TType.I32, 1);
@@ -248,9 +248,9 @@ export interface ISaveUser__ArgsArgs {
 }
 export const SaveUser__ArgsCodec: thrift.IStructCodec<ISaveUser__ArgsArgs, ISaveUser__Args> = {
     encode(args: ISaveUser__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: ISaveUser__ArgsArgs = {
+        const obj = ({
             user: args.user
-        };
+        } as ISaveUser__ArgsArgs);
         output.writeStructBegin("SaveUser__Args");
         if (obj.user != null) {
             output.writeFieldBegin("user", thrift.TType.STRUCT, 1);
@@ -387,9 +387,9 @@ export interface IGetUser__ResultArgs {
 }
 export const GetUser__ResultCodec: thrift.IStructCodec<IGetUser__ResultArgs, IGetUser__Result> = {
     encode(args: IGetUser__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IGetUser__ResultArgs = {
+        const obj = ({
             success: args.success
-        };
+        } as IGetUser__ResultArgs);
         output.writeStructBegin("GetUser__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.STRUCT, 0);

--- a/src/tests/unit/fixtures/thrift-server/annotations_service.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/annotations_service.solution.ts
@@ -387,7 +387,7 @@ export interface IGetUser__ResultArgs {
 }
 export const GetUser__ResultCodec: thrift.IStructCodec<IGetUser__ResultArgs, IGetUser__Result> = {
     encode(args: IGetUser__ResultArgs, output: thrift.TProtocol): void {
-        const obj = ({
+        let obj = ({
             success: args.success
         } as IGetUser__ResultArgs);
         output.writeStructBegin("GetUser__Result");

--- a/src/tests/unit/fixtures/thrift-server/annotations_struct.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/annotations_struct.solution.ts
@@ -9,10 +9,10 @@ export interface IMyStructArgs {
 }
 export const MyStructCodec: thrift.IStructCodec<IMyStructArgs, IMyStruct> = {
     encode(args: IMyStructArgs, output: thrift.TProtocol): void {
-        const obj: IMyStructArgs = {
+        const obj = ({
             id: (args.id != null ? args.id : 45),
             bigID: (args.bigID != null ? (typeof args.bigID === "number" ? new thrift.Int64(args.bigID) : typeof args.bigID === "string" ? thrift.Int64.fromDecimalString(args.bigID) : args.bigID) : thrift.Int64.fromDecimalString("23948234"))
-        };
+        } as IMyStructArgs);
         output.writeStructBegin("MyStruct");
         if (obj.id != null) {
             output.writeFieldBegin("id", thrift.TType.I32, 1);

--- a/src/tests/unit/fixtures/thrift-server/annotations_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/annotations_union.solution.ts
@@ -10,10 +10,10 @@ export interface IMyUnionArgs {
 export const MyUnionCodec: thrift.IStructCodec<IMyUnionArgs, IMyUnion> = {
     encode(args: IMyUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj: IMyUnionArgs = {
+        const obj = ({
             field1: args.field1,
             field2: (typeof args.field2 === "number" ? new thrift.Int64(args.field2) : typeof args.field2 === "string" ? thrift.Int64.fromDecimalString(args.field2) : args.field2)
-        };
+        } as IMyUnionArgs);
         output.writeStructBegin("MyUnion");
         if (obj.field1 != null) {
             _fieldsSet++;

--- a/src/tests/unit/fixtures/thrift-server/annotations_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/annotations_union.solution.ts
@@ -10,7 +10,7 @@ export interface IMyUnionArgs {
 export const MyUnionCodec: thrift.IStructCodec<IMyUnionArgs, IMyUnion> = {
     encode(args: IMyUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj = ({
+        let obj = ({
             field1: args.field1,
             field2: (typeof args.field2 === "number" ? new thrift.Int64(args.field2) : typeof args.field2 === "string" ? thrift.Int64.fromDecimalString(args.field2) : args.field2)
         } as IMyUnionArgs);

--- a/src/tests/unit/fixtures/thrift-server/basic_exception.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/basic_exception.solution.ts
@@ -9,10 +9,10 @@ export interface IMyExceptionArgs {
 }
 export const MyExceptionCodec: thrift.IStructCodec<IMyExceptionArgs, IMyException> = {
     encode(args: IMyExceptionArgs, output: thrift.TProtocol): void {
-        const obj: IMyExceptionArgs = {
+        const obj = ({
             message: args.message,
             code: (args.code != null ? args.code : 200)
-        };
+        } as IMyExceptionArgs);
         output.writeStructBegin("MyException");
         if (obj.message != null) {
             output.writeFieldBegin("message", thrift.TType.STRING, 1);

--- a/src/tests/unit/fixtures/thrift-server/basic_service.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/basic_service.solution.ts
@@ -375,7 +375,7 @@ export interface IGetUser__ResultArgs {
 }
 export const GetUser__ResultCodec: thrift.IStructCodec<IGetUser__ResultArgs, IGetUser__Result> = {
     encode(args: IGetUser__ResultArgs, output: thrift.TProtocol): void {
-        const obj = ({
+        let obj = ({
             success: args.success
         } as IGetUser__ResultArgs);
         output.writeStructBegin("GetUser__Result");

--- a/src/tests/unit/fixtures/thrift-server/basic_service.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/basic_service.solution.ts
@@ -9,10 +9,10 @@ export interface IUserArgs {
 }
 export const UserCodec: thrift.IStructCodec<IUserArgs, IUser> = {
     encode(args: IUserArgs, output: thrift.TProtocol): void {
-        const obj: IUserArgs = {
+        const obj = ({
             name: args.name,
             id: args.id
-        };
+        } as IUserArgs);
         output.writeStructBegin("User");
         if (obj.name != null) {
             output.writeFieldBegin("name", thrift.TType.STRING, 1);
@@ -148,9 +148,9 @@ export interface IGetUser__ArgsArgs {
 }
 export const GetUser__ArgsCodec: thrift.IStructCodec<IGetUser__ArgsArgs, IGetUser__Args> = {
     encode(args: IGetUser__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: IGetUser__ArgsArgs = {
+        const obj = ({
             id: args.id
-        };
+        } as IGetUser__ArgsArgs);
         output.writeStructBegin("GetUser__Args");
         if (obj.id != null) {
             output.writeFieldBegin("id", thrift.TType.I32, 1);
@@ -236,9 +236,9 @@ export interface ISaveUser__ArgsArgs {
 }
 export const SaveUser__ArgsCodec: thrift.IStructCodec<ISaveUser__ArgsArgs, ISaveUser__Args> = {
     encode(args: ISaveUser__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: ISaveUser__ArgsArgs = {
+        const obj = ({
             user: args.user
-        };
+        } as ISaveUser__ArgsArgs);
         output.writeStructBegin("SaveUser__Args");
         if (obj.user != null) {
             output.writeFieldBegin("user", thrift.TType.STRUCT, 1);
@@ -375,9 +375,9 @@ export interface IGetUser__ResultArgs {
 }
 export const GetUser__ResultCodec: thrift.IStructCodec<IGetUser__ResultArgs, IGetUser__Result> = {
     encode(args: IGetUser__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IGetUser__ResultArgs = {
+        const obj = ({
             success: args.success
-        };
+        } as IGetUser__ResultArgs);
         output.writeStructBegin("GetUser__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.STRUCT, 0);

--- a/src/tests/unit/fixtures/thrift-server/basic_service.strict_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/basic_service.strict_union.solution.ts
@@ -66,10 +66,10 @@ export const MyUnionCodec: thrift.IStructToolkit<MyUnionArgs, MyUnion> = {
     },
     encode(args: MyUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj: MyUnionArgs = {
+        const obj = ({
             field1: args.field1,
             field2: (typeof args.field2 === "number" ? new thrift.Int64(args.field2) : typeof args.field2 === "string" ? thrift.Int64.fromDecimalString(args.field2) : args.field2)
-        };
+        } as MyUnionArgs);
         output.writeStructBegin("MyUnion");
         if (obj.field1 != null) {
             _fieldsSet++;
@@ -187,9 +187,9 @@ export interface IGetUser__ArgsArgs {
 }
 export const GetUser__ArgsCodec: thrift.IStructCodec<IGetUser__ArgsArgs, IGetUser__Args> = {
     encode(args: IGetUser__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: IGetUser__ArgsArgs = {
+        const obj = ({
             arg1: args.arg1
-        };
+        } as IGetUser__ArgsArgs);
         output.writeStructBegin("GetUser__Args");
         if (obj.arg1 != null) {
             output.writeFieldBegin("arg1", thrift.TType.STRUCT, 1);
@@ -326,9 +326,9 @@ export interface IGetUser__ResultArgs {
 }
 export const GetUser__ResultCodec: thrift.IStructCodec<IGetUser__ResultArgs, IGetUser__Result> = {
     encode(args: IGetUser__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IGetUser__ResultArgs = {
+        const obj = ({
             success: args.success
-        };
+        } as IGetUser__ResultArgs);
         output.writeStructBegin("GetUser__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.STRING, 0);

--- a/src/tests/unit/fixtures/thrift-server/basic_service.strict_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/basic_service.strict_union.solution.ts
@@ -15,7 +15,7 @@ export interface IMyUnionWithField2 {
     field1?: undefined;
     field2: thrift.Int64;
 }
-export type MyUnionArgs = IMyUnionWithField1Args | IMyUnionWithField2Args;
+export type MyUnionArgs = IMyUnionWithField1Args | IMyUnionWithField2Args | IMyUnionDefaultArgs;
 export interface IMyUnionWithField1Args {
     field1: number;
     field2?: undefined;
@@ -23,6 +23,10 @@ export interface IMyUnionWithField1Args {
 export interface IMyUnionWithField2Args {
     field1?: undefined;
     field2: number | string | thrift.Int64;
+}
+export interface IMyUnionDefaultArgs {
+    field1?: undefined;
+    field2?: undefined;
 }
 export const MyUnionCodec: thrift.IStructToolkit<MyUnionArgs, MyUnion> = {
     create(args: MyUnionArgs): MyUnion {
@@ -66,7 +70,7 @@ export const MyUnionCodec: thrift.IStructToolkit<MyUnionArgs, MyUnion> = {
     },
     encode(args: MyUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj = ({
+        let obj = ({
             field1: args.field1,
             field2: (typeof args.field2 === "number" ? new thrift.Int64(args.field2) : typeof args.field2 === "string" ? thrift.Int64.fromDecimalString(args.field2) : args.field2)
         } as MyUnionArgs);
@@ -187,7 +191,7 @@ export interface IGetUser__ArgsArgs {
 }
 export const GetUser__ArgsCodec: thrift.IStructCodec<IGetUser__ArgsArgs, IGetUser__Args> = {
     encode(args: IGetUser__ArgsArgs, output: thrift.TProtocol): void {
-        const obj = ({
+        let obj = ({
             arg1: args.arg1
         } as IGetUser__ArgsArgs);
         output.writeStructBegin("GetUser__Args");
@@ -326,7 +330,7 @@ export interface IGetUser__ResultArgs {
 }
 export const GetUser__ResultCodec: thrift.IStructCodec<IGetUser__ResultArgs, IGetUser__Result> = {
     encode(args: IGetUser__ResultArgs, output: thrift.TProtocol): void {
-        const obj = ({
+        let obj = ({
             success: args.success
         } as IGetUser__ResultArgs);
         output.writeStructBegin("GetUser__Result");

--- a/src/tests/unit/fixtures/thrift-server/basic_struct.no_name.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/basic_struct.no_name.solution.ts
@@ -6,9 +6,9 @@ export interface IMyStructArgs {
 }
 export const MyStructCodec: thrift.IStructCodec<IMyStructArgs, IMyStruct> = {
     encode(args: IMyStructArgs, output: thrift.TProtocol): void {
-        const obj: IMyStructArgs = {
+        const obj = ({
             id: args.id
-        };
+        } as IMyStructArgs);
         output.writeStructBegin("MyStruct");
         if (obj.id != null) {
             output.writeFieldBegin("id", thrift.TType.I32, 1);

--- a/src/tests/unit/fixtures/thrift-server/basic_struct.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/basic_struct.solution.ts
@@ -15,13 +15,13 @@ export interface IMyStructArgs {
 }
 export const MyStructCodec: thrift.IStructCodec<IMyStructArgs, IMyStruct> = {
     encode(args: IMyStructArgs, output: thrift.TProtocol): void {
-        const obj: IMyStructArgs = {
+        const obj = ({
             id: (args.id != null ? args.id : 45),
             bigID: (args.bigID != null ? (typeof args.bigID === "number" ? new thrift.Int64(args.bigID) : typeof args.bigID === "string" ? thrift.Int64.fromDecimalString(args.bigID) : args.bigID) : thrift.Int64.fromDecimalString("23948234")),
             word: args.word,
             field1: args.field1,
             blob: (args.blob != null ? (typeof args.blob === "string" ? Buffer.from(args.blob) : args.blob) : Buffer.from("binary"))
-        };
+        } as IMyStructArgs);
         output.writeStructBegin("MyStruct");
         if (obj.id != null) {
             output.writeFieldBegin("id", thrift.TType.I32, 1);

--- a/src/tests/unit/fixtures/thrift-server/basic_union.no_name.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/basic_union.no_name.solution.ts
@@ -9,7 +9,7 @@ export interface IMyUnionArgs {
 export const MyUnionCodec: thrift.IStructCodec<IMyUnionArgs, IMyUnion> = {
     encode(args: IMyUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj = ({
+        let obj = ({
             option1: args.option1,
             option2: (typeof args.option2 === "number" ? new thrift.Int64(args.option2) : typeof args.option2 === "string" ? thrift.Int64.fromDecimalString(args.option2) : args.option2)
         } as IMyUnionArgs);

--- a/src/tests/unit/fixtures/thrift-server/basic_union.no_name.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/basic_union.no_name.solution.ts
@@ -9,10 +9,10 @@ export interface IMyUnionArgs {
 export const MyUnionCodec: thrift.IStructCodec<IMyUnionArgs, IMyUnion> = {
     encode(args: IMyUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj: IMyUnionArgs = {
+        const obj = ({
             option1: args.option1,
             option2: (typeof args.option2 === "number" ? new thrift.Int64(args.option2) : typeof args.option2 === "string" ? thrift.Int64.fromDecimalString(args.option2) : args.option2)
-        };
+        } as IMyUnionArgs);
         output.writeStructBegin("MyUnion");
         if (obj.option1 != null) {
             _fieldsSet++;

--- a/src/tests/unit/fixtures/thrift-server/basic_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/basic_union.solution.ts
@@ -10,10 +10,10 @@ export interface IMyUnionArgs {
 export const MyUnionCodec: thrift.IStructCodec<IMyUnionArgs, IMyUnion> = {
     encode(args: IMyUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj: IMyUnionArgs = {
+        const obj = ({
             option1: args.option1,
             option2: (typeof args.option2 === "number" ? new thrift.Int64(args.option2) : typeof args.option2 === "string" ? thrift.Int64.fromDecimalString(args.option2) : args.option2)
-        };
+        } as IMyUnionArgs);
         output.writeStructBegin("MyUnion");
         if (obj.option1 != null) {
             _fieldsSet++;

--- a/src/tests/unit/fixtures/thrift-server/basic_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/basic_union.solution.ts
@@ -10,7 +10,7 @@ export interface IMyUnionArgs {
 export const MyUnionCodec: thrift.IStructCodec<IMyUnionArgs, IMyUnion> = {
     encode(args: IMyUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj = ({
+        let obj = ({
             option1: args.option1,
             option2: (typeof args.option2 === "number" ? new thrift.Int64(args.option2) : typeof args.option2 === "string" ? thrift.Int64.fromDecimalString(args.option2) : args.option2)
         } as IMyUnionArgs);

--- a/src/tests/unit/fixtures/thrift-server/basic_union.strict_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/basic_union.strict_union.solution.ts
@@ -15,7 +15,7 @@ export interface IMyUnionWithField2 {
     field1?: undefined;
     field2: thrift.Int64;
 }
-export type MyUnionArgs = IMyUnionWithField1Args | IMyUnionWithField2Args;
+export type MyUnionArgs = IMyUnionWithField1Args | IMyUnionWithField2Args | IMyUnionDefaultArgs
 export interface IMyUnionWithField1Args {
     field1: number;
     field2?: undefined;
@@ -23,6 +23,10 @@ export interface IMyUnionWithField1Args {
 export interface IMyUnionWithField2Args {
     field1?: undefined;
     field2: number | string | thrift.Int64;
+}
+export interface IMyUnionDefaultArgs {
+    field1?: undefined;
+    field2?: undefined;
 }
 export const MyUnionCodec: thrift.IStructToolkit<MyUnionArgs, MyUnion> = {
     create(args: MyUnionArgs): MyUnion {
@@ -66,7 +70,7 @@ export const MyUnionCodec: thrift.IStructToolkit<MyUnionArgs, MyUnion> = {
     },
     encode(args: MyUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj = ({
+        let obj = ({
             field1: args.field1,
             field2: (typeof args.field2 === "number" ? new thrift.Int64(args.field2) : typeof args.field2 === "string" ? thrift.Int64.fromDecimalString(args.field2) : args.field2)
         } as MyUnionArgs);

--- a/src/tests/unit/fixtures/thrift-server/basic_union.strict_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/basic_union.strict_union.solution.ts
@@ -66,10 +66,10 @@ export const MyUnionCodec: thrift.IStructToolkit<MyUnionArgs, MyUnion> = {
     },
     encode(args: MyUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj: MyUnionArgs = {
+        const obj = ({
             field1: args.field1,
             field2: (typeof args.field2 === "number" ? new thrift.Int64(args.field2) : typeof args.field2 === "string" ? thrift.Int64.fromDecimalString(args.field2) : args.field2)
-        };
+        } as MyUnionArgs);
         output.writeStructBegin("MyUnion");
         if (obj.field1 != null) {
             _fieldsSet++;

--- a/src/tests/unit/fixtures/thrift-server/complex_nested_struct.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/complex_nested_struct.solution.ts
@@ -9,10 +9,10 @@ export interface IOtherStructArgs {
 }
 export const OtherStructCodec: thrift.IStructCodec<IOtherStructArgs, IOtherStruct> = {
     encode(args: IOtherStructArgs, output: thrift.TProtocol): void {
-        const obj: IOtherStructArgs = {
+        const obj = ({
             id: (typeof args.id === "number" ? new thrift.Int64(args.id) : typeof args.id === "string" ? thrift.Int64.fromDecimalString(args.id) : args.id),
             name: (args.name != null ? (typeof args.name === "string" ? Buffer.from(args.name) : args.name) : Buffer.from("John"))
-        };
+        } as IOtherStructArgs);
         output.writeStructBegin("OtherStruct");
         if (obj.id != null) {
             output.writeFieldBegin("id", thrift.TType.I64, 1);
@@ -132,7 +132,7 @@ export interface IMyStructArgs {
 }
 export const MyStructCodec: thrift.IStructCodec<IMyStructArgs, IMyStruct> = {
     encode(args: IMyStructArgs, output: thrift.TProtocol): void {
-        const obj: IMyStructArgs = {
+        const obj = ({
             idList: args.idList,
             idMap: args.idMap,
             idMapList: args.idMapList,
@@ -141,7 +141,7 @@ export const MyStructCodec: thrift.IStructCodec<IMyStructArgs, IMyStruct> = {
             listList: args.listList,
             listListString: args.listListString,
             i64KeyedMap: args.i64KeyedMap
-        };
+        } as IMyStructArgs);
         output.writeStructBegin("MyStruct");
         if (obj.idList != null) {
             output.writeFieldBegin("idList", thrift.TType.LIST, 1);

--- a/src/tests/unit/fixtures/thrift-server/complex_typedef.strict_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/complex_typedef.strict_union.solution.ts
@@ -70,7 +70,7 @@ export const MyUnionCodec: thrift.IStructToolkit<MyUnionArgs, MyUnion> = {
     },
     encode(args: MyUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj = ({
+        let obj = ({
             option1: args.option1,
             option2: args.option2
         } as MyUnionArgs);

--- a/src/tests/unit/fixtures/thrift-server/complex_typedef.strict_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/complex_typedef.strict_union.solution.ts
@@ -70,10 +70,10 @@ export const MyUnionCodec: thrift.IStructToolkit<MyUnionArgs, MyUnion> = {
     },
     encode(args: MyUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj: MyUnionArgs = {
+        const obj = ({
             option1: args.option1,
             option2: args.option2
-        };
+        } as MyUnionArgs);
         output.writeStructBegin("MyUnion");
         if (obj.option1 != null) {
             _fieldsSet++;

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/Code.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/Code.ts
@@ -14,9 +14,9 @@ export interface ICodeArgs {
 }
 export const CodeCodec: thrift.IStructCodec<ICodeArgs, ICode> = {
     encode(args: ICodeArgs, output: thrift.TProtocol): void {
-        const obj: ICodeArgs = {
+        const obj = ({
             status: (typeof args.status === "number" ? new thrift.Int64(args.status) : typeof args.status === "string" ? thrift.Int64.fromDecimalString(args.status) : args.status)
-        };
+        } as ICodeArgs);
         output.writeStructBegin("Code");
         if (obj.status != null) {
             output.writeFieldBegin("status", thrift.TType.I64, 1);

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/SharedService.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/SharedService.ts
@@ -41,9 +41,9 @@ export interface IGetUnion__ArgsArgs {
 }
 export const GetUnion__ArgsCodec: thrift.IStructCodec<IGetUnion__ArgsArgs, IGetUnion__Args> = {
     encode(args: IGetUnion__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: IGetUnion__ArgsArgs = {
+        const obj = ({
             index: args.index
-        };
+        } as IGetUnion__ArgsArgs);
         output.writeStructBegin("GetUnion__Args");
         if (obj.index != null) {
             output.writeFieldBegin("index", thrift.TType.I32, 1);
@@ -180,9 +180,9 @@ export interface IGetUnion__ResultArgs {
 }
 export const GetUnion__ResultCodec: thrift.IStructCodec<IGetUnion__ResultArgs, IGetUnion__Result> = {
     encode(args: IGetUnion__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IGetUnion__ResultArgs = {
+        const obj = ({
             success: args.success
-        };
+        } as IGetUnion__ResultArgs);
         output.writeStructBegin("GetUnion__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.STRUCT, 0);
@@ -257,9 +257,9 @@ export interface IGetEnum__ResultArgs {
 }
 export const GetEnum__ResultCodec: thrift.IStructCodec<IGetEnum__ResultArgs, IGetEnum__Result> = {
     encode(args: IGetEnum__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IGetEnum__ResultArgs = {
+        const obj = ({
             success: args.success
-        };
+        } as IGetEnum__ResultArgs);
         output.writeStructBegin("GetEnum__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.I32, 0);

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/SharedServiceBase.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/SharedServiceBase.ts
@@ -29,9 +29,9 @@ export interface IGetStruct__ArgsArgs {
 }
 export const GetStruct__ArgsCodec: thrift.IStructCodec<IGetStruct__ArgsArgs, IGetStruct__Args> = {
     encode(args: IGetStruct__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: IGetStruct__ArgsArgs = {
+        const obj = ({
             key: args.key
-        };
+        } as IGetStruct__ArgsArgs);
         output.writeStructBegin("GetStruct__Args");
         if (obj.key != null) {
             output.writeFieldBegin("key", thrift.TType.I32, 1);
@@ -117,9 +117,9 @@ export interface IGetStruct__ResultArgs {
 }
 export const GetStruct__ResultCodec: thrift.IStructCodec<IGetStruct__ResultArgs, IGetStruct__Result> = {
     encode(args: IGetStruct__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IGetStruct__ResultArgs = {
+        const obj = ({
             success: args.success
-        };
+        } as IGetStruct__ResultArgs);
         output.writeStructBegin("GetStruct__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.STRUCT, 0);

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/SharedStruct.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/SharedStruct.ts
@@ -19,11 +19,11 @@ export interface ISharedStructArgs {
 }
 export const SharedStructCodec: thrift.IStructCodec<ISharedStructArgs, ISharedStruct> = {
     encode(args: ISharedStructArgs, output: thrift.TProtocol): void {
-        const obj: ISharedStructArgs = {
+        const obj = ({
             code: args.code,
             value: args.value,
             mapWithDefault: (args.mapWithDefault != null ? args.mapWithDefault : new Map([]))
-        };
+        } as ISharedStructArgs);
         output.writeStructBegin("SharedStruct");
         if (obj.code != null) {
             output.writeFieldBegin("code", thrift.TType.STRUCT, 1);

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/SharedUnion.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/SharedUnion.ts
@@ -73,10 +73,10 @@ export const SharedUnionCodec: thrift.IStructToolkit<SharedUnionArgs, SharedUnio
     },
     encode(args: SharedUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj: SharedUnionArgs = {
+        const obj = ({
             option1: args.option1,
             option2: args.option2
-        };
+        } as SharedUnionArgs);
         output.writeStructBegin("SharedUnion");
         if (obj.option1 != null) {
             _fieldsSet++;

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/calculator/Calculator.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/calculator/Calculator.ts
@@ -174,10 +174,10 @@ export interface IAdd__ArgsArgs {
 }
 export const Add__ArgsCodec: thrift.IStructCodec<IAdd__ArgsArgs, IAdd__Args> = {
     encode(args: IAdd__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: IAdd__ArgsArgs = {
+        const obj = ({
             num1: args.num1,
             num2: args.num2
-        };
+        } as IAdd__ArgsArgs);
         output.writeStructBegin("Add__Args");
         if (obj.num1 != null) {
             output.writeFieldBegin("num1", thrift.TType.I32, 1);
@@ -291,10 +291,10 @@ export interface IAddInt64__ArgsArgs {
 }
 export const AddInt64__ArgsCodec: thrift.IStructCodec<IAddInt64__ArgsArgs, IAddInt64__Args> = {
     encode(args: IAddInt64__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: IAddInt64__ArgsArgs = {
+        const obj = ({
             num1: (typeof args.num1 === "number" ? new thrift.Int64(args.num1) : typeof args.num1 === "string" ? thrift.Int64.fromDecimalString(args.num1) : args.num1),
             num2: (typeof args.num2 === "number" ? new thrift.Int64(args.num2) : typeof args.num2 === "string" ? thrift.Int64.fromDecimalString(args.num2) : args.num2)
-        };
+        } as IAddInt64__ArgsArgs);
         output.writeStructBegin("AddInt64__Args");
         if (obj.num1 != null) {
             output.writeFieldBegin("num1", thrift.TType.I64, 1);
@@ -408,10 +408,10 @@ export interface IAddWithContext__ArgsArgs {
 }
 export const AddWithContext__ArgsCodec: thrift.IStructCodec<IAddWithContext__ArgsArgs, IAddWithContext__Args> = {
     encode(args: IAddWithContext__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: IAddWithContext__ArgsArgs = {
+        const obj = ({
             num1: args.num1,
             num2: args.num2
-        };
+        } as IAddWithContext__ArgsArgs);
         output.writeStructBegin("AddWithContext__Args");
         if (obj.num1 != null) {
             output.writeFieldBegin("num1", thrift.TType.I32, 1);
@@ -525,10 +525,10 @@ export interface ICalculate__ArgsArgs {
 }
 export const Calculate__ArgsCodec: thrift.IStructCodec<ICalculate__ArgsArgs, ICalculate__Args> = {
     encode(args: ICalculate__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: ICalculate__ArgsArgs = {
+        const obj = ({
             logid: args.logid,
             work: args.work
-        };
+        } as ICalculate__ArgsArgs);
         output.writeStructBegin("Calculate__Args");
         if (obj.logid != null) {
             output.writeFieldBegin("logid", thrift.TType.I32, 1);
@@ -640,9 +640,9 @@ export interface IEchoBinary__ArgsArgs {
 }
 export const EchoBinary__ArgsCodec: thrift.IStructCodec<IEchoBinary__ArgsArgs, IEchoBinary__Args> = {
     encode(args: IEchoBinary__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: IEchoBinary__ArgsArgs = {
+        const obj = ({
             word: (typeof args.word === "string" ? Buffer.from(args.word) : args.word)
-        };
+        } as IEchoBinary__ArgsArgs);
         output.writeStructBegin("EchoBinary__Args");
         if (obj.word != null) {
             output.writeFieldBegin("word", thrift.TType.STRING, 1);
@@ -728,9 +728,9 @@ export interface IEchoString__ArgsArgs {
 }
 export const EchoString__ArgsCodec: thrift.IStructCodec<IEchoString__ArgsArgs, IEchoString__Args> = {
     encode(args: IEchoString__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: IEchoString__ArgsArgs = {
+        const obj = ({
             word: args.word
-        };
+        } as IEchoString__ArgsArgs);
         output.writeStructBegin("EchoString__Args");
         if (obj.word != null) {
             output.writeFieldBegin("word", thrift.TType.STRING, 1);
@@ -816,9 +816,9 @@ export interface ICheckName__ArgsArgs {
 }
 export const CheckName__ArgsCodec: thrift.IStructCodec<ICheckName__ArgsArgs, ICheckName__Args> = {
     encode(args: ICheckName__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: ICheckName__ArgsArgs = {
+        const obj = ({
             choice: args.choice
-        };
+        } as ICheckName__ArgsArgs);
         output.writeStructBegin("CheckName__Args");
         if (obj.choice != null) {
             output.writeFieldBegin("choice", thrift.TType.STRUCT, 1);
@@ -904,9 +904,9 @@ export interface ICheckOptional__ArgsArgs {
 }
 export const CheckOptional__ArgsCodec: thrift.IStructCodec<ICheckOptional__ArgsArgs, ICheckOptional__Args> = {
     encode(args: ICheckOptional__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: ICheckOptional__ArgsArgs = {
+        const obj = ({
             type: args.type
-        };
+        } as ICheckOptional__ArgsArgs);
         output.writeStructBegin("CheckOptional__Args");
         if (obj.type != null) {
             output.writeFieldBegin("type", thrift.TType.STRING, 1);
@@ -981,9 +981,9 @@ export interface IMapOneList__ArgsArgs {
 }
 export const MapOneList__ArgsCodec: thrift.IStructCodec<IMapOneList__ArgsArgs, IMapOneList__Args> = {
     encode(args: IMapOneList__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: IMapOneList__ArgsArgs = {
+        const obj = ({
             arg: args.arg
-        };
+        } as IMapOneList__ArgsArgs);
         output.writeStructBegin("MapOneList__Args");
         if (obj.arg != null) {
             output.writeFieldBegin("arg", thrift.TType.LIST, 1);
@@ -1084,9 +1084,9 @@ export interface IMapValues__ArgsArgs {
 }
 export const MapValues__ArgsCodec: thrift.IStructCodec<IMapValues__ArgsArgs, IMapValues__Args> = {
     encode(args: IMapValues__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: IMapValues__ArgsArgs = {
+        const obj = ({
             arg: args.arg
-        };
+        } as IMapValues__ArgsArgs);
         output.writeStructBegin("MapValues__Args");
         if (obj.arg != null) {
             output.writeFieldBegin("arg", thrift.TType.MAP, 1);
@@ -1190,9 +1190,9 @@ export interface IListToMap__ArgsArgs {
 }
 export const ListToMap__ArgsCodec: thrift.IStructCodec<IListToMap__ArgsArgs, IListToMap__Args> = {
     encode(args: IListToMap__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: IListToMap__ArgsArgs = {
+        const obj = ({
             arg: args.arg
-        };
+        } as IListToMap__ArgsArgs);
         output.writeStructBegin("ListToMap__Args");
         if (obj.arg != null) {
             output.writeFieldBegin("arg", thrift.TType.LIST, 1);
@@ -1531,10 +1531,10 @@ export interface IAdd__ResultArgs {
 }
 export const Add__ResultCodec: thrift.IStructCodec<IAdd__ResultArgs, IAdd__Result> = {
     encode(args: IAdd__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IAdd__ResultArgs = {
+        const obj = ({
             success: args.success,
             exp: args.exp
-        };
+        } as IAdd__ResultArgs);
         output.writeStructBegin("Add__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.I32, 0);
@@ -1631,10 +1631,10 @@ export interface IAddInt64__ResultArgs {
 }
 export const AddInt64__ResultCodec: thrift.IStructCodec<IAddInt64__ResultArgs, IAddInt64__Result> = {
     encode(args: IAddInt64__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IAddInt64__ResultArgs = {
+        const obj = ({
             success: (typeof args.success === "number" ? new thrift.Int64(args.success) : typeof args.success === "string" ? thrift.Int64.fromDecimalString(args.success) : args.success),
             exp: args.exp
-        };
+        } as IAddInt64__ResultArgs);
         output.writeStructBegin("AddInt64__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.I64, 0);
@@ -1729,9 +1729,9 @@ export interface IAddWithContext__ResultArgs {
 }
 export const AddWithContext__ResultCodec: thrift.IStructCodec<IAddWithContext__ResultArgs, IAddWithContext__Result> = {
     encode(args: IAddWithContext__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IAddWithContext__ResultArgs = {
+        const obj = ({
             success: args.success
-        };
+        } as IAddWithContext__ResultArgs);
         output.writeStructBegin("AddWithContext__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.I32, 0);
@@ -1808,10 +1808,10 @@ export interface ICalculate__ResultArgs {
 }
 export const Calculate__ResultCodec: thrift.IStructCodec<ICalculate__ResultArgs, ICalculate__Result> = {
     encode(args: ICalculate__ResultArgs, output: thrift.TProtocol): void {
-        const obj: ICalculate__ResultArgs = {
+        const obj = ({
             success: args.success,
             ouch: args.ouch
-        };
+        } as ICalculate__ResultArgs);
         output.writeStructBegin("Calculate__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.I32, 0);
@@ -1906,9 +1906,9 @@ export interface IEchoBinary__ResultArgs {
 }
 export const EchoBinary__ResultCodec: thrift.IStructCodec<IEchoBinary__ResultArgs, IEchoBinary__Result> = {
     encode(args: IEchoBinary__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IEchoBinary__ResultArgs = {
+        const obj = ({
             success: args.success
-        };
+        } as IEchoBinary__ResultArgs);
         output.writeStructBegin("EchoBinary__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.STRING, 0);
@@ -1983,9 +1983,9 @@ export interface IEchoString__ResultArgs {
 }
 export const EchoString__ResultCodec: thrift.IStructCodec<IEchoString__ResultArgs, IEchoString__Result> = {
     encode(args: IEchoString__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IEchoString__ResultArgs = {
+        const obj = ({
             success: args.success
-        };
+        } as IEchoString__ResultArgs);
         output.writeStructBegin("EchoString__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.STRING, 0);
@@ -2060,9 +2060,9 @@ export interface ICheckName__ResultArgs {
 }
 export const CheckName__ResultCodec: thrift.IStructCodec<ICheckName__ResultArgs, ICheckName__Result> = {
     encode(args: ICheckName__ResultArgs, output: thrift.TProtocol): void {
-        const obj: ICheckName__ResultArgs = {
+        const obj = ({
             success: args.success
-        };
+        } as ICheckName__ResultArgs);
         output.writeStructBegin("CheckName__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.STRING, 0);
@@ -2137,9 +2137,9 @@ export interface ICheckOptional__ResultArgs {
 }
 export const CheckOptional__ResultCodec: thrift.IStructCodec<ICheckOptional__ResultArgs, ICheckOptional__Result> = {
     encode(args: ICheckOptional__ResultArgs, output: thrift.TProtocol): void {
-        const obj: ICheckOptional__ResultArgs = {
+        const obj = ({
             success: args.success
-        };
+        } as ICheckOptional__ResultArgs);
         output.writeStructBegin("CheckOptional__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.STRING, 0);
@@ -2214,9 +2214,9 @@ export interface IMapOneList__ResultArgs {
 }
 export const MapOneList__ResultCodec: thrift.IStructCodec<IMapOneList__ResultArgs, IMapOneList__Result> = {
     encode(args: IMapOneList__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IMapOneList__ResultArgs = {
+        const obj = ({
             success: args.success
-        };
+        } as IMapOneList__ResultArgs);
         output.writeStructBegin("MapOneList__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.LIST, 0);
@@ -2306,9 +2306,9 @@ export interface IMapValues__ResultArgs {
 }
 export const MapValues__ResultCodec: thrift.IStructCodec<IMapValues__ResultArgs, IMapValues__Result> = {
     encode(args: IMapValues__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IMapValues__ResultArgs = {
+        const obj = ({
             success: args.success
-        };
+        } as IMapValues__ResultArgs);
         output.writeStructBegin("MapValues__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.LIST, 0);
@@ -2398,9 +2398,9 @@ export interface IListToMap__ResultArgs {
 }
 export const ListToMap__ResultCodec: thrift.IStructCodec<IListToMap__ResultArgs, IListToMap__Result> = {
     encode(args: IListToMap__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IListToMap__ResultArgs = {
+        const obj = ({
             success: args.success
-        };
+        } as IListToMap__ResultArgs);
         output.writeStructBegin("ListToMap__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.MAP, 0);
@@ -2493,9 +2493,9 @@ export interface IFetchThing__ResultArgs {
 }
 export const FetchThing__ResultCodec: thrift.IStructCodec<IFetchThing__ResultArgs, IFetchThing__Result> = {
     encode(args: IFetchThing__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IFetchThing__ResultArgs = {
+        const obj = ({
             success: args.success
-        };
+        } as IFetchThing__ResultArgs);
         output.writeStructBegin("FetchThing__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.STRUCT, 0);
@@ -2570,9 +2570,9 @@ export interface IFetchMap__ResultArgs {
 }
 export const FetchMap__ResultCodec: thrift.IStructCodec<IFetchMap__ResultArgs, IFetchMap__Result> = {
     encode(args: IFetchMap__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IFetchMap__ResultArgs = {
+        const obj = ({
             success: args.success
-        };
+        } as IFetchMap__ResultArgs);
         output.writeStructBegin("FetchMap__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.MAP, 0);

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/calculator/Choice.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/calculator/Choice.ts
@@ -75,10 +75,10 @@ export const ChoiceCodec: thrift.IStructToolkit<ChoiceArgs, Choice> = {
     },
     encode(args: ChoiceArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj: ChoiceArgs = {
+        const obj = ({
             firstName: args.firstName,
             lastName: args.lastName
-        };
+        } as ChoiceArgs);
         output.writeStructBegin("Choice");
         if (obj.firstName != null) {
             _fieldsSet++;

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/calculator/FirstName.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/calculator/FirstName.ts
@@ -14,9 +14,9 @@ export interface IFirstNameArgs {
 }
 export const FirstNameCodec: thrift.IStructCodec<IFirstNameArgs, IFirstName> = {
     encode(args: IFirstNameArgs, output: thrift.TProtocol): void {
-        const obj: IFirstNameArgs = {
+        const obj = ({
             name: args.name
-        };
+        } as IFirstNameArgs);
         output.writeStructBegin("FirstName");
         if (obj.name != null) {
             output.writeFieldBegin("name", thrift.TType.STRING, 1);

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/calculator/LastName.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/calculator/LastName.ts
@@ -14,9 +14,9 @@ export interface ILastNameArgs {
 }
 export const LastNameCodec: thrift.IStructCodec<ILastNameArgs, ILastName> = {
     encode(args: ILastNameArgs, output: thrift.TProtocol): void {
-        const obj: ILastNameArgs = {
+        const obj = ({
             name: args.name
-        };
+        } as ILastNameArgs);
         output.writeStructBegin("LastName");
         if (obj.name != null) {
             output.writeFieldBegin("name", thrift.TType.STRING, 1);

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/calculator/NotAGoodIdea.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/calculator/NotAGoodIdea.ts
@@ -18,10 +18,10 @@ export interface INotAGoodIdeaArgs {
 }
 export const NotAGoodIdeaCodec: thrift.IStructCodec<INotAGoodIdeaArgs, INotAGoodIdea> = {
     encode(args: INotAGoodIdeaArgs, output: thrift.TProtocol): void {
-        const obj: INotAGoodIdeaArgs = {
+        const obj = ({
             message: args.message,
             data: args.data
-        };
+        } as INotAGoodIdeaArgs);
         output.writeStructBegin("NotAGoodIdea");
         if (obj.message != null) {
             output.writeFieldBegin("message", thrift.TType.STRING, 1);

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/calculator/Work.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/calculator/Work.ts
@@ -21,12 +21,12 @@ export interface IWorkArgs {
 }
 export const WorkCodec: thrift.IStructCodec<IWorkArgs, IWork> = {
     encode(args: IWorkArgs, output: thrift.TProtocol): void {
-        const obj: IWorkArgs = {
+        const obj = ({
             num1: (args.num1 != null ? args.num1 : 0),
             num2: args.num2,
             op: (args.op != null ? args.op : Operation.Operation.ADD),
             comment: args.comment
-        };
+        } as IWorkArgs);
         output.writeStructBegin("Work");
         if (obj.num1 != null) {
             output.writeFieldBegin("num1", thrift.TType.I32, 1);

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/common/AuthException.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/common/AuthException.ts
@@ -16,10 +16,10 @@ export interface IAuthExceptionArgs {
 }
 export const AuthExceptionCodec: thrift.IStructCodec<IAuthExceptionArgs, IAuthException> = {
     encode(args: IAuthExceptionArgs, output: thrift.TProtocol): void {
-        const obj: IAuthExceptionArgs = {
+        const obj = ({
             code: args.code,
             message: args.message
-        };
+        } as IAuthExceptionArgs);
         output.writeStructBegin("AuthException");
         if (obj.code != null) {
             output.writeFieldBegin("code", thrift.TType.I32, 1);

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/common/OtherCommonUnion.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/common/OtherCommonUnion.ts
@@ -73,10 +73,10 @@ export const OtherCommonUnionCodec: thrift.IStructToolkit<OtherCommonUnionArgs, 
     },
     encode(args: OtherCommonUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj: OtherCommonUnionArgs = {
+        const obj = ({
             option1: args.option1,
             option2: args.option2
-        };
+        } as OtherCommonUnionArgs);
         output.writeStructBegin("OtherCommonUnion");
         if (obj.option1 != null) {
             _fieldsSet++;

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/exceptions/InvalidOperation.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/exceptions/InvalidOperation.ts
@@ -16,10 +16,10 @@ export interface IInvalidOperationArgs {
 }
 export const InvalidOperationCodec: thrift.IStructCodec<IInvalidOperationArgs, IInvalidOperation> = {
     encode(args: IInvalidOperationArgs, output: thrift.TProtocol): void {
-        const obj: IInvalidOperationArgs = {
+        const obj = ({
             whatOp: args.whatOp,
             why: args.why
-        };
+        } as IInvalidOperationArgs);
         output.writeStructBegin("InvalidOperation");
         if (obj.whatOp != null) {
             output.writeFieldBegin("whatOp", thrift.TType.I32, 1);

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/exceptions/InvalidResult.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/exceptions/InvalidResult.ts
@@ -17,10 +17,10 @@ export interface IInvalidResultArgs {
 }
 export const InvalidResultCodec: thrift.IStructCodec<IInvalidResultArgs, IInvalidResult> = {
     encode(args: IInvalidResultArgs, output: thrift.TProtocol): void {
-        const obj: IInvalidResultArgs = {
+        const obj = ({
             message: args.message,
             code: args.code
-        };
+        } as IInvalidResultArgs);
         output.writeStructBegin("InvalidResult");
         if (obj.message != null) {
             output.writeFieldBegin("message", thrift.TType.STRING, 1);

--- a/src/tests/unit/fixtures/thrift-server/generated/Code.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/Code.ts
@@ -14,9 +14,9 @@ export interface ICodeArgs {
 }
 export const CodeCodec: thrift.IStructCodec<ICodeArgs, ICode> = {
     encode(args: ICodeArgs, output: thrift.TProtocol): void {
-        const obj: ICodeArgs = {
+        const obj = ({
             status: (typeof args.status === "number" ? new thrift.Int64(args.status) : typeof args.status === "string" ? thrift.Int64.fromDecimalString(args.status) : args.status)
-        };
+        } as ICodeArgs);
         output.writeStructBegin("Code");
         if (obj.status != null) {
             output.writeFieldBegin("status", thrift.TType.I64, 1);

--- a/src/tests/unit/fixtures/thrift-server/generated/SharedService.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/SharedService.ts
@@ -41,9 +41,9 @@ export interface IGetUnion__ArgsArgs {
 }
 export const GetUnion__ArgsCodec: thrift.IStructCodec<IGetUnion__ArgsArgs, IGetUnion__Args> = {
     encode(args: IGetUnion__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: IGetUnion__ArgsArgs = {
+        const obj = ({
             index: args.index
-        };
+        } as IGetUnion__ArgsArgs);
         output.writeStructBegin("GetUnion__Args");
         if (obj.index != null) {
             output.writeFieldBegin("index", thrift.TType.I32, 1);
@@ -180,9 +180,9 @@ export interface IGetUnion__ResultArgs {
 }
 export const GetUnion__ResultCodec: thrift.IStructCodec<IGetUnion__ResultArgs, IGetUnion__Result> = {
     encode(args: IGetUnion__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IGetUnion__ResultArgs = {
+        const obj = ({
             success: args.success
-        };
+        } as IGetUnion__ResultArgs);
         output.writeStructBegin("GetUnion__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.STRUCT, 0);
@@ -257,9 +257,9 @@ export interface IGetEnum__ResultArgs {
 }
 export const GetEnum__ResultCodec: thrift.IStructCodec<IGetEnum__ResultArgs, IGetEnum__Result> = {
     encode(args: IGetEnum__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IGetEnum__ResultArgs = {
+        const obj = ({
             success: args.success
-        };
+        } as IGetEnum__ResultArgs);
         output.writeStructBegin("GetEnum__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.I32, 0);

--- a/src/tests/unit/fixtures/thrift-server/generated/SharedServiceBase.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/SharedServiceBase.ts
@@ -29,9 +29,9 @@ export interface IGetStruct__ArgsArgs {
 }
 export const GetStruct__ArgsCodec: thrift.IStructCodec<IGetStruct__ArgsArgs, IGetStruct__Args> = {
     encode(args: IGetStruct__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: IGetStruct__ArgsArgs = {
+        const obj = ({
             key: args.key
-        };
+        } as IGetStruct__ArgsArgs);
         output.writeStructBegin("GetStruct__Args");
         if (obj.key != null) {
             output.writeFieldBegin("key", thrift.TType.I32, 1);
@@ -117,9 +117,9 @@ export interface IGetStruct__ResultArgs {
 }
 export const GetStruct__ResultCodec: thrift.IStructCodec<IGetStruct__ResultArgs, IGetStruct__Result> = {
     encode(args: IGetStruct__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IGetStruct__ResultArgs = {
+        const obj = ({
             success: args.success
-        };
+        } as IGetStruct__ResultArgs);
         output.writeStructBegin("GetStruct__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.STRUCT, 0);

--- a/src/tests/unit/fixtures/thrift-server/generated/SharedStruct.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/SharedStruct.ts
@@ -19,11 +19,11 @@ export interface ISharedStructArgs {
 }
 export const SharedStructCodec: thrift.IStructCodec<ISharedStructArgs, ISharedStruct> = {
     encode(args: ISharedStructArgs, output: thrift.TProtocol): void {
-        const obj: ISharedStructArgs = {
+        const obj = ({
             code: args.code,
             value: args.value,
             mapWithDefault: (args.mapWithDefault != null ? args.mapWithDefault : new Map([]))
-        };
+        } as ISharedStructArgs);
         output.writeStructBegin("SharedStruct");
         if (obj.code != null) {
             output.writeFieldBegin("code", thrift.TType.STRUCT, 1);

--- a/src/tests/unit/fixtures/thrift-server/generated/SharedUnion.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/SharedUnion.ts
@@ -17,10 +17,10 @@ export interface ISharedUnionArgs {
 export const SharedUnionCodec: thrift.IStructCodec<ISharedUnionArgs, ISharedUnion> = {
     encode(args: ISharedUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj: ISharedUnionArgs = {
+        const obj = ({
             option1: args.option1,
             option2: args.option2
-        };
+        } as ISharedUnionArgs);
         output.writeStructBegin("SharedUnion");
         if (obj.option1 != null) {
             _fieldsSet++;

--- a/src/tests/unit/fixtures/thrift-server/generated/com/test/calculator/Calculator.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/com/test/calculator/Calculator.ts
@@ -174,10 +174,10 @@ export interface IAdd__ArgsArgs {
 }
 export const Add__ArgsCodec: thrift.IStructCodec<IAdd__ArgsArgs, IAdd__Args> = {
     encode(args: IAdd__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: IAdd__ArgsArgs = {
+        const obj = ({
             num1: args.num1,
             num2: args.num2
-        };
+        } as IAdd__ArgsArgs);
         output.writeStructBegin("Add__Args");
         if (obj.num1 != null) {
             output.writeFieldBegin("num1", thrift.TType.I32, 1);
@@ -291,10 +291,10 @@ export interface IAddInt64__ArgsArgs {
 }
 export const AddInt64__ArgsCodec: thrift.IStructCodec<IAddInt64__ArgsArgs, IAddInt64__Args> = {
     encode(args: IAddInt64__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: IAddInt64__ArgsArgs = {
+        const obj = ({
             num1: (typeof args.num1 === "number" ? new thrift.Int64(args.num1) : typeof args.num1 === "string" ? thrift.Int64.fromDecimalString(args.num1) : args.num1),
             num2: (typeof args.num2 === "number" ? new thrift.Int64(args.num2) : typeof args.num2 === "string" ? thrift.Int64.fromDecimalString(args.num2) : args.num2)
-        };
+        } as IAddInt64__ArgsArgs);
         output.writeStructBegin("AddInt64__Args");
         if (obj.num1 != null) {
             output.writeFieldBegin("num1", thrift.TType.I64, 1);
@@ -408,10 +408,10 @@ export interface IAddWithContext__ArgsArgs {
 }
 export const AddWithContext__ArgsCodec: thrift.IStructCodec<IAddWithContext__ArgsArgs, IAddWithContext__Args> = {
     encode(args: IAddWithContext__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: IAddWithContext__ArgsArgs = {
+        const obj = ({
             num1: args.num1,
             num2: args.num2
-        };
+        } as IAddWithContext__ArgsArgs);
         output.writeStructBegin("AddWithContext__Args");
         if (obj.num1 != null) {
             output.writeFieldBegin("num1", thrift.TType.I32, 1);
@@ -525,10 +525,10 @@ export interface ICalculate__ArgsArgs {
 }
 export const Calculate__ArgsCodec: thrift.IStructCodec<ICalculate__ArgsArgs, ICalculate__Args> = {
     encode(args: ICalculate__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: ICalculate__ArgsArgs = {
+        const obj = ({
             logid: args.logid,
             work: args.work
-        };
+        } as ICalculate__ArgsArgs);
         output.writeStructBegin("Calculate__Args");
         if (obj.logid != null) {
             output.writeFieldBegin("logid", thrift.TType.I32, 1);
@@ -640,9 +640,9 @@ export interface IEchoBinary__ArgsArgs {
 }
 export const EchoBinary__ArgsCodec: thrift.IStructCodec<IEchoBinary__ArgsArgs, IEchoBinary__Args> = {
     encode(args: IEchoBinary__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: IEchoBinary__ArgsArgs = {
+        const obj = ({
             word: (typeof args.word === "string" ? Buffer.from(args.word) : args.word)
-        };
+        } as IEchoBinary__ArgsArgs);
         output.writeStructBegin("EchoBinary__Args");
         if (obj.word != null) {
             output.writeFieldBegin("word", thrift.TType.STRING, 1);
@@ -728,9 +728,9 @@ export interface IEchoString__ArgsArgs {
 }
 export const EchoString__ArgsCodec: thrift.IStructCodec<IEchoString__ArgsArgs, IEchoString__Args> = {
     encode(args: IEchoString__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: IEchoString__ArgsArgs = {
+        const obj = ({
             word: args.word
-        };
+        } as IEchoString__ArgsArgs);
         output.writeStructBegin("EchoString__Args");
         if (obj.word != null) {
             output.writeFieldBegin("word", thrift.TType.STRING, 1);
@@ -816,9 +816,9 @@ export interface ICheckName__ArgsArgs {
 }
 export const CheckName__ArgsCodec: thrift.IStructCodec<ICheckName__ArgsArgs, ICheckName__Args> = {
     encode(args: ICheckName__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: ICheckName__ArgsArgs = {
+        const obj = ({
             choice: args.choice
-        };
+        } as ICheckName__ArgsArgs);
         output.writeStructBegin("CheckName__Args");
         if (obj.choice != null) {
             output.writeFieldBegin("choice", thrift.TType.STRUCT, 1);
@@ -904,9 +904,9 @@ export interface ICheckOptional__ArgsArgs {
 }
 export const CheckOptional__ArgsCodec: thrift.IStructCodec<ICheckOptional__ArgsArgs, ICheckOptional__Args> = {
     encode(args: ICheckOptional__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: ICheckOptional__ArgsArgs = {
+        const obj = ({
             type: args.type
-        };
+        } as ICheckOptional__ArgsArgs);
         output.writeStructBegin("CheckOptional__Args");
         if (obj.type != null) {
             output.writeFieldBegin("type", thrift.TType.STRING, 1);
@@ -981,9 +981,9 @@ export interface IMapOneList__ArgsArgs {
 }
 export const MapOneList__ArgsCodec: thrift.IStructCodec<IMapOneList__ArgsArgs, IMapOneList__Args> = {
     encode(args: IMapOneList__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: IMapOneList__ArgsArgs = {
+        const obj = ({
             arg: args.arg
-        };
+        } as IMapOneList__ArgsArgs);
         output.writeStructBegin("MapOneList__Args");
         if (obj.arg != null) {
             output.writeFieldBegin("arg", thrift.TType.LIST, 1);
@@ -1084,9 +1084,9 @@ export interface IMapValues__ArgsArgs {
 }
 export const MapValues__ArgsCodec: thrift.IStructCodec<IMapValues__ArgsArgs, IMapValues__Args> = {
     encode(args: IMapValues__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: IMapValues__ArgsArgs = {
+        const obj = ({
             arg: args.arg
-        };
+        } as IMapValues__ArgsArgs);
         output.writeStructBegin("MapValues__Args");
         if (obj.arg != null) {
             output.writeFieldBegin("arg", thrift.TType.MAP, 1);
@@ -1190,9 +1190,9 @@ export interface IListToMap__ArgsArgs {
 }
 export const ListToMap__ArgsCodec: thrift.IStructCodec<IListToMap__ArgsArgs, IListToMap__Args> = {
     encode(args: IListToMap__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: IListToMap__ArgsArgs = {
+        const obj = ({
             arg: args.arg
-        };
+        } as IListToMap__ArgsArgs);
         output.writeStructBegin("ListToMap__Args");
         if (obj.arg != null) {
             output.writeFieldBegin("arg", thrift.TType.LIST, 1);
@@ -1531,10 +1531,10 @@ export interface IAdd__ResultArgs {
 }
 export const Add__ResultCodec: thrift.IStructCodec<IAdd__ResultArgs, IAdd__Result> = {
     encode(args: IAdd__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IAdd__ResultArgs = {
+        const obj = ({
             success: args.success,
             exp: args.exp
-        };
+        } as IAdd__ResultArgs);
         output.writeStructBegin("Add__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.I32, 0);
@@ -1631,10 +1631,10 @@ export interface IAddInt64__ResultArgs {
 }
 export const AddInt64__ResultCodec: thrift.IStructCodec<IAddInt64__ResultArgs, IAddInt64__Result> = {
     encode(args: IAddInt64__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IAddInt64__ResultArgs = {
+        const obj = ({
             success: (typeof args.success === "number" ? new thrift.Int64(args.success) : typeof args.success === "string" ? thrift.Int64.fromDecimalString(args.success) : args.success),
             exp: args.exp
-        };
+        } as IAddInt64__ResultArgs);
         output.writeStructBegin("AddInt64__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.I64, 0);
@@ -1729,9 +1729,9 @@ export interface IAddWithContext__ResultArgs {
 }
 export const AddWithContext__ResultCodec: thrift.IStructCodec<IAddWithContext__ResultArgs, IAddWithContext__Result> = {
     encode(args: IAddWithContext__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IAddWithContext__ResultArgs = {
+        const obj = ({
             success: args.success
-        };
+        } as IAddWithContext__ResultArgs);
         output.writeStructBegin("AddWithContext__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.I32, 0);
@@ -1808,10 +1808,10 @@ export interface ICalculate__ResultArgs {
 }
 export const Calculate__ResultCodec: thrift.IStructCodec<ICalculate__ResultArgs, ICalculate__Result> = {
     encode(args: ICalculate__ResultArgs, output: thrift.TProtocol): void {
-        const obj: ICalculate__ResultArgs = {
+        const obj = ({
             success: args.success,
             ouch: args.ouch
-        };
+        } as ICalculate__ResultArgs);
         output.writeStructBegin("Calculate__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.I32, 0);
@@ -1906,9 +1906,9 @@ export interface IEchoBinary__ResultArgs {
 }
 export const EchoBinary__ResultCodec: thrift.IStructCodec<IEchoBinary__ResultArgs, IEchoBinary__Result> = {
     encode(args: IEchoBinary__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IEchoBinary__ResultArgs = {
+        const obj = ({
             success: args.success
-        };
+        } as IEchoBinary__ResultArgs);
         output.writeStructBegin("EchoBinary__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.STRING, 0);
@@ -1983,9 +1983,9 @@ export interface IEchoString__ResultArgs {
 }
 export const EchoString__ResultCodec: thrift.IStructCodec<IEchoString__ResultArgs, IEchoString__Result> = {
     encode(args: IEchoString__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IEchoString__ResultArgs = {
+        const obj = ({
             success: args.success
-        };
+        } as IEchoString__ResultArgs);
         output.writeStructBegin("EchoString__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.STRING, 0);
@@ -2060,9 +2060,9 @@ export interface ICheckName__ResultArgs {
 }
 export const CheckName__ResultCodec: thrift.IStructCodec<ICheckName__ResultArgs, ICheckName__Result> = {
     encode(args: ICheckName__ResultArgs, output: thrift.TProtocol): void {
-        const obj: ICheckName__ResultArgs = {
+        const obj = ({
             success: args.success
-        };
+        } as ICheckName__ResultArgs);
         output.writeStructBegin("CheckName__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.STRING, 0);
@@ -2137,9 +2137,9 @@ export interface ICheckOptional__ResultArgs {
 }
 export const CheckOptional__ResultCodec: thrift.IStructCodec<ICheckOptional__ResultArgs, ICheckOptional__Result> = {
     encode(args: ICheckOptional__ResultArgs, output: thrift.TProtocol): void {
-        const obj: ICheckOptional__ResultArgs = {
+        const obj = ({
             success: args.success
-        };
+        } as ICheckOptional__ResultArgs);
         output.writeStructBegin("CheckOptional__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.STRING, 0);
@@ -2214,9 +2214,9 @@ export interface IMapOneList__ResultArgs {
 }
 export const MapOneList__ResultCodec: thrift.IStructCodec<IMapOneList__ResultArgs, IMapOneList__Result> = {
     encode(args: IMapOneList__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IMapOneList__ResultArgs = {
+        const obj = ({
             success: args.success
-        };
+        } as IMapOneList__ResultArgs);
         output.writeStructBegin("MapOneList__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.LIST, 0);
@@ -2306,9 +2306,9 @@ export interface IMapValues__ResultArgs {
 }
 export const MapValues__ResultCodec: thrift.IStructCodec<IMapValues__ResultArgs, IMapValues__Result> = {
     encode(args: IMapValues__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IMapValues__ResultArgs = {
+        const obj = ({
             success: args.success
-        };
+        } as IMapValues__ResultArgs);
         output.writeStructBegin("MapValues__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.LIST, 0);
@@ -2398,9 +2398,9 @@ export interface IListToMap__ResultArgs {
 }
 export const ListToMap__ResultCodec: thrift.IStructCodec<IListToMap__ResultArgs, IListToMap__Result> = {
     encode(args: IListToMap__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IListToMap__ResultArgs = {
+        const obj = ({
             success: args.success
-        };
+        } as IListToMap__ResultArgs);
         output.writeStructBegin("ListToMap__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.MAP, 0);
@@ -2493,9 +2493,9 @@ export interface IFetchThing__ResultArgs {
 }
 export const FetchThing__ResultCodec: thrift.IStructCodec<IFetchThing__ResultArgs, IFetchThing__Result> = {
     encode(args: IFetchThing__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IFetchThing__ResultArgs = {
+        const obj = ({
             success: args.success
-        };
+        } as IFetchThing__ResultArgs);
         output.writeStructBegin("FetchThing__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.STRUCT, 0);
@@ -2570,9 +2570,9 @@ export interface IFetchMap__ResultArgs {
 }
 export const FetchMap__ResultCodec: thrift.IStructCodec<IFetchMap__ResultArgs, IFetchMap__Result> = {
     encode(args: IFetchMap__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IFetchMap__ResultArgs = {
+        const obj = ({
             success: args.success
-        };
+        } as IFetchMap__ResultArgs);
         output.writeStructBegin("FetchMap__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.MAP, 0);

--- a/src/tests/unit/fixtures/thrift-server/generated/com/test/calculator/Choice.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/com/test/calculator/Choice.ts
@@ -19,10 +19,10 @@ export interface IChoiceArgs {
 export const ChoiceCodec: thrift.IStructCodec<IChoiceArgs, IChoice> = {
     encode(args: IChoiceArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj: IChoiceArgs = {
+        const obj = ({
             firstName: args.firstName,
             lastName: args.lastName
-        };
+        } as IChoiceArgs);
         output.writeStructBegin("Choice");
         if (obj.firstName != null) {
             _fieldsSet++;

--- a/src/tests/unit/fixtures/thrift-server/generated/com/test/calculator/FirstName.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/com/test/calculator/FirstName.ts
@@ -14,9 +14,9 @@ export interface IFirstNameArgs {
 }
 export const FirstNameCodec: thrift.IStructCodec<IFirstNameArgs, IFirstName> = {
     encode(args: IFirstNameArgs, output: thrift.TProtocol): void {
-        const obj: IFirstNameArgs = {
+        const obj = ({
             name: args.name
-        };
+        } as IFirstNameArgs);
         output.writeStructBegin("FirstName");
         if (obj.name != null) {
             output.writeFieldBegin("name", thrift.TType.STRING, 1);

--- a/src/tests/unit/fixtures/thrift-server/generated/com/test/calculator/LastName.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/com/test/calculator/LastName.ts
@@ -14,9 +14,9 @@ export interface ILastNameArgs {
 }
 export const LastNameCodec: thrift.IStructCodec<ILastNameArgs, ILastName> = {
     encode(args: ILastNameArgs, output: thrift.TProtocol): void {
-        const obj: ILastNameArgs = {
+        const obj = ({
             name: args.name
-        };
+        } as ILastNameArgs);
         output.writeStructBegin("LastName");
         if (obj.name != null) {
             output.writeFieldBegin("name", thrift.TType.STRING, 1);

--- a/src/tests/unit/fixtures/thrift-server/generated/com/test/calculator/NotAGoodIdea.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/com/test/calculator/NotAGoodIdea.ts
@@ -18,10 +18,10 @@ export interface INotAGoodIdeaArgs {
 }
 export const NotAGoodIdeaCodec: thrift.IStructCodec<INotAGoodIdeaArgs, INotAGoodIdea> = {
     encode(args: INotAGoodIdeaArgs, output: thrift.TProtocol): void {
-        const obj: INotAGoodIdeaArgs = {
+        const obj = ({
             message: args.message,
             data: args.data
-        };
+        } as INotAGoodIdeaArgs);
         output.writeStructBegin("NotAGoodIdea");
         if (obj.message != null) {
             output.writeFieldBegin("message", thrift.TType.STRING, 1);

--- a/src/tests/unit/fixtures/thrift-server/generated/com/test/calculator/Work.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/com/test/calculator/Work.ts
@@ -21,12 +21,12 @@ export interface IWorkArgs {
 }
 export const WorkCodec: thrift.IStructCodec<IWorkArgs, IWork> = {
     encode(args: IWorkArgs, output: thrift.TProtocol): void {
-        const obj: IWorkArgs = {
+        const obj = ({
             num1: (args.num1 != null ? args.num1 : 0),
             num2: args.num2,
             op: (args.op != null ? args.op : Operation.Operation.ADD),
             comment: args.comment
-        };
+        } as IWorkArgs);
         output.writeStructBegin("Work");
         if (obj.num1 != null) {
             output.writeFieldBegin("num1", thrift.TType.I32, 1);

--- a/src/tests/unit/fixtures/thrift-server/generated/com/test/common/AuthException.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/com/test/common/AuthException.ts
@@ -16,10 +16,10 @@ export interface IAuthExceptionArgs {
 }
 export const AuthExceptionCodec: thrift.IStructCodec<IAuthExceptionArgs, IAuthException> = {
     encode(args: IAuthExceptionArgs, output: thrift.TProtocol): void {
-        const obj: IAuthExceptionArgs = {
+        const obj = ({
             code: args.code,
             message: args.message
-        };
+        } as IAuthExceptionArgs);
         output.writeStructBegin("AuthException");
         if (obj.code != null) {
             output.writeFieldBegin("code", thrift.TType.I32, 1);

--- a/src/tests/unit/fixtures/thrift-server/generated/com/test/common/OtherCommonUnion.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/com/test/common/OtherCommonUnion.ts
@@ -17,10 +17,10 @@ export interface IOtherCommonUnionArgs {
 export const OtherCommonUnionCodec: thrift.IStructCodec<IOtherCommonUnionArgs, IOtherCommonUnion> = {
     encode(args: IOtherCommonUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj: IOtherCommonUnionArgs = {
+        const obj = ({
             option1: args.option1,
             option2: args.option2
-        };
+        } as IOtherCommonUnionArgs);
         output.writeStructBegin("OtherCommonUnion");
         if (obj.option1 != null) {
             _fieldsSet++;

--- a/src/tests/unit/fixtures/thrift-server/generated/com/test/exceptions/InvalidOperation.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/com/test/exceptions/InvalidOperation.ts
@@ -16,10 +16,10 @@ export interface IInvalidOperationArgs {
 }
 export const InvalidOperationCodec: thrift.IStructCodec<IInvalidOperationArgs, IInvalidOperation> = {
     encode(args: IInvalidOperationArgs, output: thrift.TProtocol): void {
-        const obj: IInvalidOperationArgs = {
+        const obj = ({
             whatOp: args.whatOp,
             why: args.why
-        };
+        } as IInvalidOperationArgs);
         output.writeStructBegin("InvalidOperation");
         if (obj.whatOp != null) {
             output.writeFieldBegin("whatOp", thrift.TType.I32, 1);

--- a/src/tests/unit/fixtures/thrift-server/generated/com/test/exceptions/InvalidResult.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/com/test/exceptions/InvalidResult.ts
@@ -17,10 +17,10 @@ export interface IInvalidResultArgs {
 }
 export const InvalidResultCodec: thrift.IStructCodec<IInvalidResultArgs, IInvalidResult> = {
     encode(args: IInvalidResultArgs, output: thrift.TProtocol): void {
-        const obj: IInvalidResultArgs = {
+        const obj = ({
             message: args.message,
             code: args.code
-        };
+        } as IInvalidResultArgs);
         output.writeStructBegin("InvalidResult");
         if (obj.message != null) {
             output.writeFieldBegin("message", thrift.TType.STRING, 1);

--- a/src/tests/unit/fixtures/thrift-server/i64_service.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/i64_service.solution.ts
@@ -7,9 +7,9 @@ export interface ICodeArgs {
 }
 export const CodeCodec: thrift.IStructCodec<ICodeArgs, ICode> = {
     encode(args: ICodeArgs, output: thrift.TProtocol): void {
-        const obj: ICodeArgs = {
+        const obj = ({
             status: (typeof args.status === "number" ? new thrift.Int64(args.status) : typeof args.status === "string" ? thrift.Int64.fromDecimalString(args.status) : args.status)
-        };
+        } as ICodeArgs);
         output.writeStructBegin("Code");
         if (obj.status != null) {
             output.writeFieldBegin("status", thrift.TType.I64, 1);
@@ -103,9 +103,9 @@ export interface IPeg__ArgsArgs {
 }
 export const Peg__ArgsCodec: thrift.IStructCodec<IPeg__ArgsArgs, IPeg__Args> = {
     encode(args: IPeg__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: IPeg__ArgsArgs = {
+        const obj = ({
             name: args.name
-        };
+        } as IPeg__ArgsArgs);
         output.writeStructBegin("Peg__Args");
         if (obj.name != null) {
             output.writeFieldBegin("name", thrift.TType.STRING, 1);
@@ -191,9 +191,9 @@ export interface IPong__ArgsArgs {
 }
 export const Pong__ArgsCodec: thrift.IStructCodec<IPong__ArgsArgs, IPong__Args> = {
     encode(args: IPong__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: IPong__ArgsArgs = {
+        const obj = ({
             code: args.code
-        };
+        } as IPong__ArgsArgs);
         output.writeStructBegin("Pong__Args");
         if (obj.code != null) {
             output.writeFieldBegin("code", thrift.TType.STRUCT, 1);
@@ -268,9 +268,9 @@ export interface IPeg__ResultArgs {
 }
 export const Peg__ResultCodec: thrift.IStructCodec<IPeg__ResultArgs, IPeg__Result> = {
     encode(args: IPeg__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IPeg__ResultArgs = {
+        const obj = ({
             success: args.success
-        };
+        } as IPeg__ResultArgs);
         output.writeStructBegin("Peg__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.STRING, 0);
@@ -345,9 +345,9 @@ export interface IPong__ResultArgs {
 }
 export const Pong__ResultCodec: thrift.IStructCodec<IPong__ResultArgs, IPong__Result> = {
     encode(args: IPong__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IPong__ResultArgs = {
+        const obj = ({
             success: (typeof args.success === "number" ? new thrift.Int64(args.success) : typeof args.success === "string" ? thrift.Int64.fromDecimalString(args.success) : args.success)
-        };
+        } as IPong__ResultArgs);
         output.writeStructBegin("Pong__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.I64, 0);

--- a/src/tests/unit/fixtures/thrift-server/initialized_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/initialized_union.solution.ts
@@ -9,10 +9,10 @@ export interface IMyUnionArgs {
 export const MyUnionCodec: thrift.IStructCodec<IMyUnionArgs, IMyUnion> = {
     encode(args: IMyUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj: IMyUnionArgs = {
+        const obj = ({
             option1: args.option1,
             option2: (typeof args.option2 === "number" ? new thrift.Int64(args.option2) : typeof args.option2 === "string" ? thrift.Int64.fromDecimalString(args.option2) : args.option2)
-        };
+        } as IMyUnionArgs);
         if (obj.option1 == null && obj.option2 == null) {
             obj.option1 = "test";
         }

--- a/src/tests/unit/fixtures/thrift-server/initialized_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/initialized_union.solution.ts
@@ -9,12 +9,12 @@ export interface IMyUnionArgs {
 export const MyUnionCodec: thrift.IStructCodec<IMyUnionArgs, IMyUnion> = {
     encode(args: IMyUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj = ({
+        let obj = ({
             option1: args.option1,
             option2: (typeof args.option2 === "number" ? new thrift.Int64(args.option2) : typeof args.option2 === "string" ? thrift.Int64.fromDecimalString(args.option2) : args.option2)
         } as IMyUnionArgs);
         if (obj.option1 == null && obj.option2 == null) {
-            obj.option1 = "test";
+            obj = { option1: "test" };
         }
         output.writeStructBegin("MyUnion");
         if (obj.option1 != null) {

--- a/src/tests/unit/fixtures/thrift-server/initialized_union.strict_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/initialized_union.strict_union.solution.ts
@@ -15,7 +15,7 @@ export interface IMyUnionWithField2 {
     field1?: undefined;
     field2: thrift.Int64;
 }
-export type MyUnionArgs = IMyUnionWithField1Args | IMyUnionWithField2Args;
+export type MyUnionArgs = IMyUnionWithField1Args | IMyUnionWithField2Args | IMyUnionDefaultArgs
 export interface IMyUnionWithField1Args {
     field1: number;
     field2?: undefined;
@@ -23,6 +23,10 @@ export interface IMyUnionWithField1Args {
 export interface IMyUnionWithField2Args {
     field1?: undefined;
     field2: number | string | thrift.Int64;
+}
+export interface IMyUnionDefaultArgs {
+    field1?: undefined;
+    field2?: undefined;
 }
 export const MyUnionCodec: thrift.IStructToolkit<MyUnionArgs, MyUnion> = {
     create(args: MyUnionArgs): MyUnion {
@@ -66,7 +70,7 @@ export const MyUnionCodec: thrift.IStructToolkit<MyUnionArgs, MyUnion> = {
     },
     encode(args: MyUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj = ({
+        let obj = ({
             field1: args.field1,
             field2: (typeof args.field2 === "number" ? new thrift.Int64(args.field2) : typeof args.field2 === "string" ? thrift.Int64.fromDecimalString(args.field2) : args.field2)
         } as MyUnionArgs);

--- a/src/tests/unit/fixtures/thrift-server/initialized_union.strict_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/initialized_union.strict_union.solution.ts
@@ -66,10 +66,10 @@ export const MyUnionCodec: thrift.IStructToolkit<MyUnionArgs, MyUnion> = {
     },
     encode(args: MyUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj: MyUnionArgs = {
+        const obj = ({
             field1: args.field1,
             field2: (typeof args.field2 === "number" ? new thrift.Int64(args.field2) : typeof args.field2 === "string" ? thrift.Int64.fromDecimalString(args.field2) : args.field2)
-        };
+        } as MyUnionArgs);
         if (obj.field1 == null && obj.field2 == null) {
             obj.field1 = 32;
         }

--- a/src/tests/unit/fixtures/thrift-server/multi_field_struct.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/multi_field_struct.solution.ts
@@ -15,13 +15,13 @@ export interface IMyStructArgs {
 }
 export const MyStructCodec: thrift.IStructCodec<IMyStructArgs, IMyStruct> = {
     encode(args: IMyStructArgs, output: thrift.TProtocol): void {
-        const obj: IMyStructArgs = {
+        const obj = ({
             id: (args.id != null ? args.id : 45),
             bigID: (args.bigID != null ? (typeof args.bigID === "number" ? new thrift.Int64(args.bigID) : typeof args.bigID === "string" ? thrift.Int64.fromDecimalString(args.bigID) : args.bigID) : thrift.Int64.fromDecimalString("23948234")),
             word: args.word,
             field1: args.field1,
             blob: (args.blob != null ? (typeof args.blob === "string" ? Buffer.from(args.blob) : args.blob) : Buffer.from("binary"))
-        };
+        } as IMyStructArgs);
         output.writeStructBegin("MyStruct");
         if (obj.id != null) {
             output.writeFieldBegin("id", thrift.TType.I32, 1);

--- a/src/tests/unit/fixtures/thrift-server/nested_exception.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/nested_exception.solution.ts
@@ -9,10 +9,10 @@ export interface ICodeArgs {
 }
 export const CodeCodec: thrift.IStructCodec<ICodeArgs, ICode> = {
     encode(args: ICodeArgs, output: thrift.TProtocol): void {
-        const obj: ICodeArgs = {
+        const obj = ({
             status: (args.status != null ? (typeof args.status === "number" ? new thrift.Int64(args.status) : typeof args.status === "string" ? thrift.Int64.fromDecimalString(args.status) : args.status) : thrift.Int64.fromDecimalString("200")),
             data: (args.data != null ? (typeof args.data === "string" ? Buffer.from(args.data) : args.data) : Buffer.from("data"))
-        };
+        } as ICodeArgs);
         output.writeStructBegin("Code");
         if (obj.status != null) {
             output.writeFieldBegin("status", thrift.TType.I64, 1);
@@ -109,10 +109,10 @@ export interface IMyExceptionArgs {
 }
 export const MyExceptionCodec: thrift.IStructCodec<IMyExceptionArgs, IMyException> = {
     encode(args: IMyExceptionArgs, output: thrift.TProtocol): void {
-        const obj: IMyExceptionArgs = {
+        const obj = ({
             description: args.description,
             code: args.code
-        };
+        } as IMyExceptionArgs);
         output.writeStructBegin("MyException");
         if (obj.description != null) {
             output.writeFieldBegin("description", thrift.TType.STRING, 1);

--- a/src/tests/unit/fixtures/thrift-server/nested_struct.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/nested_struct.solution.ts
@@ -9,10 +9,10 @@ export interface IUserArgs {
 }
 export const UserCodec: thrift.IStructCodec<IUserArgs, IUser> = {
     encode(args: IUserArgs, output: thrift.TProtocol): void {
-        const obj: IUserArgs = {
+        const obj = ({
             name: args.name,
             age: (args.age != null ? (typeof args.age === "number" ? new thrift.Int64(args.age) : typeof args.age === "string" ? thrift.Int64.fromDecimalString(args.age) : args.age) : thrift.Int64.fromDecimalString("45"))
-        };
+        } as IUserArgs);
         output.writeStructBegin("User");
         if (obj.name != null) {
             output.writeFieldBegin("name", thrift.TType.STRING, 1);
@@ -120,10 +120,10 @@ export interface IMyStructArgs {
 }
 export const MyStructCodec: thrift.IStructCodec<IMyStructArgs, IMyStruct> = {
     encode(args: IMyStructArgs, output: thrift.TProtocol): void {
-        const obj: IMyStructArgs = {
+        const obj = ({
             name: args.name,
             user: args.user
-        };
+        } as IMyStructArgs);
         output.writeStructBegin("MyStruct");
         if (obj.name != null) {
             output.writeFieldBegin("name", thrift.TType.STRING, 1);

--- a/src/tests/unit/fixtures/thrift-server/nested_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/nested_union.solution.ts
@@ -10,7 +10,7 @@ export interface IOptionArgs {
 export const OptionCodec: thrift.IStructCodec<IOptionArgs, IOption> = {
     encode(args: IOptionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj = ({
+        let obj = ({
             option1: (typeof args.option1 === "string" ? Buffer.from(args.option1) : args.option1),
             option2: (typeof args.option2 === "number" ? new thrift.Int64(args.option2) : typeof args.option2 === "string" ? thrift.Int64.fromDecimalString(args.option2) : args.option2)
         } as IOptionArgs);
@@ -149,7 +149,7 @@ export interface IMyUnionArgs {
 export const MyUnionCodec: thrift.IStructCodec<IMyUnionArgs, IMyUnion> = {
     encode(args: IMyUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj = ({
+        let obj = ({
             name: args.name,
             option: args.option
         } as IMyUnionArgs);

--- a/src/tests/unit/fixtures/thrift-server/nested_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/nested_union.solution.ts
@@ -10,10 +10,10 @@ export interface IOptionArgs {
 export const OptionCodec: thrift.IStructCodec<IOptionArgs, IOption> = {
     encode(args: IOptionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj: IOptionArgs = {
+        const obj = ({
             option1: (typeof args.option1 === "string" ? Buffer.from(args.option1) : args.option1),
             option2: (typeof args.option2 === "number" ? new thrift.Int64(args.option2) : typeof args.option2 === "string" ? thrift.Int64.fromDecimalString(args.option2) : args.option2)
-        };
+        } as IOptionArgs);
         output.writeStructBegin("Option");
         if (obj.option1 != null) {
             _fieldsSet++;
@@ -149,10 +149,10 @@ export interface IMyUnionArgs {
 export const MyUnionCodec: thrift.IStructCodec<IMyUnionArgs, IMyUnion> = {
     encode(args: IMyUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj: IMyUnionArgs = {
+        const obj = ({
             name: args.name,
             option: args.option
-        };
+        } as IMyUnionArgs);
         output.writeStructBegin("MyUnion");
         if (obj.name != null) {
             _fieldsSet++;

--- a/src/tests/unit/fixtures/thrift-server/nested_union.strict_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/nested_union.strict_union.solution.ts
@@ -66,10 +66,10 @@ export const InnerUnionCodec: thrift.IStructToolkit<InnerUnionArgs, InnerUnion> 
     },
     encode(args: InnerUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj: InnerUnionArgs = {
+        const obj = ({
             name: args.name,
             id: args.id
-        };
+        } as InnerUnionArgs);
         output.writeStructBegin("InnerUnion");
         if (obj.name != null) {
             _fieldsSet++;
@@ -227,10 +227,10 @@ export const MyUnionCodec: thrift.IStructToolkit<MyUnionArgs, MyUnion> = {
     },
     encode(args: MyUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj: MyUnionArgs = {
+        const obj = ({
             user: args.user,
             field2: args.field2
-        };
+        } as MyUnionArgs);
         output.writeStructBegin("MyUnion");
         if (obj.user != null) {
             _fieldsSet++;

--- a/src/tests/unit/fixtures/thrift-server/nested_union.strict_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/nested_union.strict_union.solution.ts
@@ -66,7 +66,7 @@ export const InnerUnionCodec: thrift.IStructToolkit<InnerUnionArgs, InnerUnion> 
     },
     encode(args: InnerUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj = ({
+        let obj = ({
             name: args.name,
             id: args.id
         } as InnerUnionArgs);
@@ -227,7 +227,7 @@ export const MyUnionCodec: thrift.IStructToolkit<MyUnionArgs, MyUnion> = {
     },
     encode(args: MyUnionArgs, output: thrift.TProtocol): void {
         let _fieldsSet: number = 0;
-        const obj = ({
+        let obj = ({
             user: args.user,
             field2: args.field2
         } as MyUnionArgs);

--- a/src/tests/unit/fixtures/thrift-server/required_field_exception.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/required_field_exception.solution.ts
@@ -9,10 +9,10 @@ export interface IMyExceptionArgs {
 }
 export const MyExceptionCodec: thrift.IStructCodec<IMyExceptionArgs, IMyException> = {
     encode(args: IMyExceptionArgs, output: thrift.TProtocol): void {
-        const obj: IMyExceptionArgs = {
+        const obj = ({
             description: args.description,
             code: args.code
-        };
+        } as IMyExceptionArgs);
         output.writeStructBegin("MyException");
         if (obj.description != null) {
             output.writeFieldBegin("description", thrift.TType.STRING, 1);

--- a/src/tests/unit/fixtures/thrift-server/resolved_field_service.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/resolved_field_service.solution.ts
@@ -22,9 +22,9 @@ export interface IPing__ArgsArgs {
 }
 export const Ping__ArgsCodec: thrift.IStructCodec<IPing__ArgsArgs, IPing__Args> = {
     encode(args: IPing__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: IPing__ArgsArgs = {
+        const obj = ({
             id: (typeof args.id === "number" ? new thrift.Int64(args.id) : typeof args.id === "string" ? thrift.Int64.fromDecimalString(args.id) : args.id)
-        };
+        } as IPing__ArgsArgs);
         output.writeStructBegin("Ping__Args");
         if (obj.id != null) {
             output.writeFieldBegin("id", thrift.TType.I64, 1);

--- a/src/tests/unit/fixtures/thrift-server/throws_multi_service.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/throws_multi_service.solution.ts
@@ -7,9 +7,9 @@ export interface IServiceExceptionArgs {
 }
 export const ServiceExceptionCodec: thrift.IStructCodec<IServiceExceptionArgs, IServiceException> = {
     encode(args: IServiceExceptionArgs, output: thrift.TProtocol): void {
-        const obj: IServiceExceptionArgs = {
+        const obj = ({
             message: args.message
-        };
+        } as IServiceExceptionArgs);
         output.writeStructBegin("ServiceException");
         if (obj.message != null) {
             output.writeFieldBegin("message", thrift.TType.STRING, 1);
@@ -86,10 +86,10 @@ export interface IAuthExceptionArgs {
 }
 export const AuthExceptionCodec: thrift.IStructCodec<IAuthExceptionArgs, IAuthException> = {
     encode(args: IAuthExceptionArgs, output: thrift.TProtocol): void {
-        const obj: IAuthExceptionArgs = {
+        const obj = ({
             message: args.message,
             code: args.code
-        };
+        } as IAuthExceptionArgs);
         output.writeStructBegin("AuthException");
         if (obj.message != null) {
             output.writeFieldBegin("message", thrift.TType.STRING, 1);
@@ -184,9 +184,9 @@ export interface IUnknownExceptionArgs {
 }
 export const UnknownExceptionCodec: thrift.IStructCodec<IUnknownExceptionArgs, IUnknownException> = {
     encode(args: IUnknownExceptionArgs, output: thrift.TProtocol): void {
-        const obj: IUnknownExceptionArgs = {
+        const obj = ({
             message: args.message
-        };
+        } as IUnknownExceptionArgs);
         output.writeStructBegin("UnknownException");
         if (obj.message != null) {
             output.writeFieldBegin("message", thrift.TType.STRING, 1);
@@ -275,9 +275,9 @@ export interface IPeg__ArgsArgs {
 }
 export const Peg__ArgsCodec: thrift.IStructCodec<IPeg__ArgsArgs, IPeg__Args> = {
     encode(args: IPeg__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: IPeg__ArgsArgs = {
+        const obj = ({
             name: args.name
-        };
+        } as IPeg__ArgsArgs);
         output.writeStructBegin("Peg__Args");
         if (obj.name != null) {
             output.writeFieldBegin("name", thrift.TType.STRING, 1);
@@ -369,12 +369,12 @@ export interface IPeg__ResultArgs {
 }
 export const Peg__ResultCodec: thrift.IStructCodec<IPeg__ResultArgs, IPeg__Result> = {
     encode(args: IPeg__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IPeg__ResultArgs = {
+        const obj = ({
             success: args.success,
             exp: args.exp,
             authExp: args.authExp,
             unknownExp: args.unknownExp
-        };
+        } as IPeg__ResultArgs);
         output.writeStructBegin("Peg__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.STRING, 0);

--- a/src/tests/unit/fixtures/thrift-server/throws_service.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/throws_service.solution.ts
@@ -7,9 +7,9 @@ export interface IServiceExceptionArgs {
 }
 export const ServiceExceptionCodec: thrift.IStructCodec<IServiceExceptionArgs, IServiceException> = {
     encode(args: IServiceExceptionArgs, output: thrift.TProtocol): void {
-        const obj: IServiceExceptionArgs = {
+        const obj = ({
             message: args.message
-        };
+        } as IServiceExceptionArgs);
         output.writeStructBegin("ServiceException");
         if (obj.message != null) {
             output.writeFieldBegin("message", thrift.TType.STRING, 1);
@@ -103,9 +103,9 @@ export interface IPeg__ArgsArgs {
 }
 export const Peg__ArgsCodec: thrift.IStructCodec<IPeg__ArgsArgs, IPeg__Args> = {
     encode(args: IPeg__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: IPeg__ArgsArgs = {
+        const obj = ({
             name: args.name
-        };
+        } as IPeg__ArgsArgs);
         output.writeStructBegin("Peg__Args");
         if (obj.name != null) {
             output.writeFieldBegin("name", thrift.TType.STRING, 1);
@@ -191,9 +191,9 @@ export interface IPong__ArgsArgs {
 }
 export const Pong__ArgsCodec: thrift.IStructCodec<IPong__ArgsArgs, IPong__Args> = {
     encode(args: IPong__ArgsArgs, output: thrift.TProtocol): void {
-        const obj: IPong__ArgsArgs = {
+        const obj = ({
             name: args.name
-        };
+        } as IPong__ArgsArgs);
         output.writeStructBegin("Pong__Args");
         if (obj.name != null) {
             output.writeFieldBegin("name", thrift.TType.STRING, 1);
@@ -270,10 +270,10 @@ export interface IPeg__ResultArgs {
 }
 export const Peg__ResultCodec: thrift.IStructCodec<IPeg__ResultArgs, IPeg__Result> = {
     encode(args: IPeg__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IPeg__ResultArgs = {
+        const obj = ({
             success: args.success,
             exp: args.exp
-        };
+        } as IPeg__ResultArgs);
         output.writeStructBegin("Peg__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.STRING, 0);
@@ -368,9 +368,9 @@ export interface IPong__ResultArgs {
 }
 export const Pong__ResultCodec: thrift.IStructCodec<IPong__ResultArgs, IPong__Result> = {
     encode(args: IPong__ResultArgs, output: thrift.TProtocol): void {
-        const obj: IPong__ResultArgs = {
+        const obj = ({
             success: args.success
-        };
+        } as IPong__ResultArgs);
         output.writeStructBegin("Pong__Result");
         if (obj.success != null) {
             output.writeFieldBegin("success", thrift.TType.STRING, 0);


### PR DESCRIPTION
@kevin-greene-ck this should fix #166 


I could separate the logic for unions vs structs if you think it would be better to keep the previous logic for structs.  I think the `as` cast is required for unions though.