### PR TITLE
Return non-zero exit code on parse failures

### DIFF
--- a/src/main/bin/index.ts
+++ b/src/main/bin/index.ts
@@ -6,4 +6,6 @@ import { resolveOptions } from './resolveOptions'
 const cliArgs: Array<string> = process.argv.slice(2)
 const options: IMakeOptions = resolveOptions(cliArgs)
 
-generate(options)
+generate(options).catch(() => {
+    process.exit(1)
+})


### PR DESCRIPTION
Currently, when thrift-typescript fails to parse a file, you get the following logs from node: (after the parse error is printed by the parser)

```
(node:40855) UnhandledPromiseRejectionWarning: Error: Unable to parse source: 
    at parseThriftString (/Users/paul/var/Underwriter/node_modules/@creditkarma/thrift-typescript/dist/main/parser/index.js:11:19)
    at Object.parseThriftFile (/Users/paul/var/Underwriter/node_modules/@creditkarma/thrift-typescript/dist/main/parser/index.js:25:23)
    at /Users/paul/var/Underwriter/node_modules/@creditkarma/thrift-typescript/dist/main/index.js:69:67
    at Array.map (<anonymous>)
    at thriftProjectFromSourceFiles (/Users/paul/var/Underwriter/node_modules/@creditkarma/thrift-typescript/dist/main/index.js:69:37)
    at processThriftProject (/Users/paul/var/Underwriter/node_modules/@creditkarma/thrift-typescript/dist/main/index.js:114:12)
    at async Object.generate (/Users/paul/var/Underwriter/node_modules/@creditkarma/thrift-typescript/dist/main/index.js:118:27)
(node:40855) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:40855) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

This results in an exit code of 0. 
These failures produced a nonzero exit code, which would be helpful for scripting/chaining/etc.

This PR proposes to catch any otherwise unhandled promise rejections and `exit(1)` instead of waiting for node to do this in the future. 