### PR TITLE
fix type issue with map constants that reference other maps or sets

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -158,9 +158,9 @@ export function thriftProjectFromSourceFiles(
         {},
     )
 
-    const resolvedInvalidFiles: Array<
-        INamespace
-    > = Debugger.collectInvalidFiles(Utils.valuesForObject(resolvedNamespaces))
+    const resolvedInvalidFiles: Array<INamespace> = Debugger.collectInvalidFiles(
+        Utils.valuesForObject(resolvedNamespaces),
+    )
 
     if (resolvedInvalidFiles.length > 0) {
         Debugger.printErrors(resolvedInvalidFiles)
@@ -174,9 +174,7 @@ export function thriftProjectFromSourceFiles(
             return acc
         }, {})
 
-        const validatedInvalidFiles: Array<
-            INamespace
-        > = Debugger.collectInvalidFiles(
+        const validatedInvalidFiles: Array<INamespace> = Debugger.collectInvalidFiles(
             Utils.valuesForObject(validatedNamespaces),
         )
 

--- a/src/main/render/apache/struct/create.ts
+++ b/src/main/render/apache/struct/create.ts
@@ -55,9 +55,9 @@ export function renderStruct(
         createFieldAssignment,
     )
 
-    const argsParameter: Array<
-        ts.ParameterDeclaration
-    > = createArgsParameterForStruct(node)
+    const argsParameter: Array<ts.ParameterDeclaration> = createArgsParameterForStruct(
+        node,
+    )
 
     // Build the constructor body
     const ctor: ts.ConstructorDeclaration = createClassConstructor(

--- a/src/main/render/apache/union.ts
+++ b/src/main/render/apache/union.ts
@@ -93,9 +93,9 @@ export function renderUnion(
         undefined, // else
     )
 
-    const argsParameter: Array<
-        ts.ParameterDeclaration
-    > = createArgsParameterForStruct(node)
+    const argsParameter: Array<ts.ParameterDeclaration> = createArgsParameterForStruct(
+        node,
+    )
 
     // let fieldsSet: number = 0;
     const fieldsSet: ts.VariableStatement = createFieldIncrementer()

--- a/src/main/render/thrift-server/initializers.ts
+++ b/src/main/render/thrift-server/initializers.ts
@@ -18,6 +18,7 @@ import { COMMON_IDENTIFIERS } from './identifiers'
 
 import { Resolver } from '../../resolver'
 import { IRenderState } from '../../types'
+import { typeNodeForFieldType } from './types'
 import { propertyAccessForIdentifier } from './utils'
 
 export function renderValue(
@@ -132,9 +133,14 @@ function renderMap(
         ])
     })
 
-    return ts.createNew(COMMON_IDENTIFIERS.Map, undefined, [
-        ts.createArrayLiteral(values),
-    ])
+    return ts.createNew(
+        COMMON_IDENTIFIERS.Map,
+        [
+            typeNodeForFieldType(fieldType.keyType, state),
+            typeNodeForFieldType(fieldType.valueType, state),
+        ],
+        [ts.createArrayLiteral(values)],
+    )
 }
 
 function renderSet(

--- a/src/tests/integration/apache/index.spec.ts
+++ b/src/tests/integration/apache/index.spec.ts
@@ -183,7 +183,12 @@ describe('Thrift TypeScript', () => {
 
     it('should correctly call endpoint with maps as parameters', async () => {
         return thriftClient
-            .mapValues(new Map([['key1', 6], ['key2', 5]]))
+            .mapValues(
+                new Map([
+                    ['key1', 6],
+                    ['key2', 5],
+                ]),
+            )
             .then((response: Array<number>) => {
                 assert.deepEqual(response, [6, 5])
             })
@@ -191,11 +196,17 @@ describe('Thrift TypeScript', () => {
 
     it('should correctly call endpoint that returns a map', async () => {
         return thriftClient
-            .listToMap([['key_1', 'value_1'], ['key_2', 'value_2']])
+            .listToMap([
+                ['key_1', 'value_1'],
+                ['key_2', 'value_2'],
+            ])
             .then((response: Map<string, string>) => {
                 assert.deepEqual(
                     response,
-                    new Map([['key_1', 'value_1'], ['key_2', 'value_2']]),
+                    new Map([
+                        ['key_1', 'value_1'],
+                        ['key_2', 'value_2'],
+                    ]),
                 )
             })
     })

--- a/src/tests/unit/fixtures/thrift-server/complex_const.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/complex_const.solution.ts
@@ -1,9 +1,14 @@
+export enum MyEnum {
+    ONE = 0,
+    TWO = 1
+}
 export const WHAT: number = 32;
 export const VALUE: number = 32;
 export const VALUE_LIST: Array<number> = [32];
 export const FALSE_CONST: boolean = false;
 export const INT_64: thrift.Int64 = thrift.Int64.fromDecimalString("64");
 export const SET_CONST: Set<string> = new Set(["hello", "world", "foo", "bar"]);
-export const MAP_CONST: Map<string, string> = new Map([["hello", "world"], ["foo", "bar"]]);
-export const VALUE_MAP: Map<number, string> = new Map([[32, "world"], [5, "bar"]]);
+export const MAP_CONST: Map<string, string> = new Map<string, string>([["hello", "world"], ["foo", "bar"]]);
+export const VALUE_MAP: Map<number, string> = new Map<number, string>([[32, "world"], [5, "bar"]]);
 export const LIST_CONST: Array<string> = ["hello", "world", "foo", "bar"];
+export const MAP_WITH_ENUM_SET: Map<string, Set<MyEnum>> = new Map<string, Set<MyEnum>>([["hello", new Set([MyEnum.ONE])], ["foo", new Set([MyEnum.TWO])]]);

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/calculator/constants.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/calculator/constants.ts
@@ -5,4 +5,4 @@
  * DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 */
 export const INT32CONSTANT: number = 9853;
-export const MAPCONSTANT: Map<string, string> = new Map([["hello", "world"], ["goodnight", "moon"]]);
+export const MAPCONSTANT: Map<string, string> = new Map<string, string>([["hello", "world"], ["goodnight", "moon"]]);

--- a/src/tests/unit/fixtures/thrift-server/generated/com/test/calculator/constants.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/com/test/calculator/constants.ts
@@ -5,4 +5,4 @@
  * DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 */
 export const INT32CONSTANT: number = 9853;
-export const MAPCONSTANT: Map<string, string> = new Map([["hello", "world"], ["goodnight", "moon"]]);
+export const MAPCONSTANT: Map<string, string> = new Map<string, string>([["hello", "world"], ["goodnight", "moon"]]);

--- a/src/tests/unit/index.spec.ts
+++ b/src/tests/unit/index.spec.ts
@@ -297,6 +297,11 @@ describe('Thrift TypeScript Generator', () => {
                 const map<string,string> MAP_CONST = {'hello': 'world', 'foo': 'bar' }
                 const map<i32,string> VALUE_MAP = { VALUE: 'world', 5: 'bar' }
                 const list<string> LIST_CONST = ['hello', 'world', 'foo', 'bar']
+                enum MyEnum {
+                    ONE,
+                    TWO
+                }
+                const map<string,set<MyEnum>> MAP_WITH_ENUM_SET = {'hello': [MyEnum.ONE], 'foo': [MyEnum.TWO] }
             `
             const expected: string = readSolution('complex_const')
             const actual: string = make(content, {


### PR DESCRIPTION
The initializer arrays for generated map constants don't always type check correctly. 

Basically the issue happens when the inferred type of 2 map entries are different

```ts
const map: Map<string, Set<Enum> = new Map<[
  ['abc', new Set([Enum.One], // [string, Set<1>]
  ['abc', new Set([Enum.Two],  [string, Set<2>]
  ]) // error with something like (['abc', new Set([Enum.Two] || [string, Set<2>])[] is not assignable to [string, Set<Set<Enum>][]
```

Adding explicit type to the map fixes this.
