### PR TITLE
Fix vscode settings and remove 'loose' param from recursive TypeNode calls

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,3 +16,4 @@
       "coverage.lcov": true
     },
     "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/src/main/render/apache/types.ts
+++ b/src/main/render/apache/types.ts
@@ -245,18 +245,18 @@ export function typeNodeForFieldType(
 
         case SyntaxType.SetType:
             return ts.createTypeReferenceNode(COMMON_IDENTIFIERS.Set, [
-                typeNodeForFieldType(fieldType.valueType, state, loose),
+                typeNodeForFieldType(fieldType.valueType, state),
             ])
 
         case SyntaxType.MapType:
             return ts.createTypeReferenceNode(COMMON_IDENTIFIERS.Map, [
-                typeNodeForFieldType(fieldType.keyType, state, loose),
-                typeNodeForFieldType(fieldType.valueType, state, loose),
+                typeNodeForFieldType(fieldType.keyType, state),
+                typeNodeForFieldType(fieldType.valueType, state),
             ])
 
         case SyntaxType.ListType:
             return createArrayType(
-                typeNodeForFieldType(fieldType.valueType, state, loose),
+                typeNodeForFieldType(fieldType.valueType, state),
             )
 
         case SyntaxType.StringKeyword:

--- a/src/tests/integration/thrift/user.thrift
+++ b/src/tests/integration/thrift/user.thrift
@@ -7,4 +7,5 @@ struct User {
 
 service UserService {
     User getUser(1: i64 id)
+    list<User> getUsers(1: list<i64> ids)
 }


### PR DESCRIPTION
Having container types with `i64` generates bad code when used in a service definition. Making the interface stricter prevents bad type assignments.

Also adds test case in `user.thrift`.

Recursive loose `i64`'s could work but it requires changes across the renderer to use `coerceType()` and `typeNodeForFieldType()` differently. Both solutions could cause compatibility issues and I'm open to doing either.

### Example:
The following thrift
```thrift
service UserService {
    i32 sum(1: list<i64> vals)
}
```
Would generate
```typescript
export interface ISumArgsArgs {
    vals: Array<number | Int64>;
}
export class SumArgs {
    public vals: Array<Int64>;
    constructor(args: ISumArgsArgs) {
        if (args != null && args.vals != null) {
            this.vals = args.vals;
        }
        else {
            throw new thrift.Thrift.TProtocolException(thrift.Thrift.TProtocolExceptionType.UNKNOWN, "Required field[vals] is unset!");
        }
    }
    // ...
}
```
The compiler would fail at `this.vals = args.vals` because of the type mismatch.

After these changes it will generate the following interface instead:
```typescript
export interface ISumArgsArgs {
    vals: Array<Int64>;
}
```