### PR TITLE
Add server-side logging of non-Thrift exceptions.

### DIFF
--- a/src/main/render/apache/service/processor.ts
+++ b/src/main/render/apache/service/processor.ts
@@ -303,11 +303,13 @@ export function renderProcessor(
 //             result.populate({{{throwName}}: err as {{throwType}}})
 //             output.writeMessageBegin("{{name}}", Thrift.MessageType.REPLY, seqid)
 //         } else {{/throws}}{
+//             console.error('Unexpected exception...', err)
 //             result = new Thrift.TApplicationException(Thrift.TApplicationExceptionType.UNKNOWN, err.message)
 //             output.writeMessageBegin("{{name}}", Thrift.MessageType.EXCEPTION, seqid)
 //         }
 //         {{/hasThrows}}
 //         {{^hasThrows}}
+//         console.error('Unexpected exception...', err)
 //         result = new Thrift.TApplicationException(Thrift.TApplicationExceptionType.UNKNOWN, err.message)
 //         output.writeMessageBegin("{{name}}", Thrift.MessageType.EXCEPTION, seqid)
 //         {{/hasThrows}}
@@ -568,6 +570,13 @@ function createElseForExceptions(
     } else {
         return ts.createBlock(
             [
+                // console.error('Unexpected exception...', err)
+                createMethodCallStatement(COMMON_IDENTIFIERS.console, 'error', [
+                    ts.createLiteral(
+                        `Unexpected exception while handling ${funcDef.name.value}: `,
+                    ),
+                    COMMON_IDENTIFIERS.err,
+                ]),
                 // const result: Thrift.TApplicationException = new Thrift.TApplicationException(Thrift.TApplicationExceptionType.UNKNOWN, err.message)
                 createConstStatement(
                     COMMON_IDENTIFIERS.result,
@@ -708,6 +717,13 @@ function createExceptionHandlers(
         return [createIfForExceptions(funcDef.throws, funcDef, state)]
     } else {
         return [
+            // console.error('Unexpected exception...', err)
+            createMethodCallStatement(COMMON_IDENTIFIERS.console, 'error', [
+                ts.createLiteral(
+                    `Unexpected exception while handling ${funcDef.name.value}: `,
+                ),
+                COMMON_IDENTIFIERS.err,
+            ]),
             // const result: Thrift.TApplicationException = new Thrift.TApplicationException(Thrift.TApplicationExceptionType.UNKNOWN, err.message)
             createConstStatement(
                 COMMON_IDENTIFIERS.result,

--- a/src/main/render/shared/identifiers.ts
+++ b/src/main/render/shared/identifiers.ts
@@ -83,4 +83,5 @@ export const COMMON_IDENTIFIERS = {
     Node_Int64: ts.createIdentifier('Int64'),
     readStructBegin: ts.createIdentifier('readStructBegin'),
     readStructEnd: ts.createIdentifier('readStructEnd'),
+    console: ts.createIdentifier('console'),
 }

--- a/src/main/render/thrift-server/service/processor.ts
+++ b/src/main/render/thrift-server/service/processor.ts
@@ -534,6 +534,13 @@ function createElseForExceptions(
     } else {
         return ts.createBlock(
             [
+                // console.error('Unexpected exception...', err)
+                createMethodCallStatement(COMMON_IDENTIFIERS.console, 'error', [
+                    ts.createLiteral(
+                        `Unexpected exception while handling ${funcDef.name.value}: `,
+                    ),
+                    COMMON_IDENTIFIERS.err,
+                ]),
                 // const result: Thrift.TApplicationException = new thrift.TApplicationException(Thrift.TApplicationExceptionType.UNKNOWN, err.message)
                 createConstStatement(
                     COMMON_IDENTIFIERS.result,
@@ -674,6 +681,13 @@ function createExceptionHandlers(
         return [createIfForExceptions(funcDef.throws, funcDef, state)]
     } else {
         return [
+            // console.error('Unexpected exception...', err)
+            createMethodCallStatement(COMMON_IDENTIFIERS.console, 'error', [
+                ts.createLiteral(
+                    `Unexpected exception while handling ${funcDef.name.value}: `,
+                ),
+                COMMON_IDENTIFIERS.err,
+            ]),
             // const result: Thrift.TApplicationException = new thrift.TApplicationException(Thrift.TApplicationExceptionType.UNKNOWN, err.message)
             createConstStatement(
                 COMMON_IDENTIFIERS.result,

--- a/src/tests/unit/fixtures/apache/basic_service.solution.ts
+++ b/src/tests/unit/fixtures/apache/basic_service.solution.ts
@@ -177,6 +177,7 @@ export class Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
+            console.error("Unexpected exception while handling ping: ", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("ping", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);

--- a/src/tests/unit/fixtures/apache/generated/SharedService.ts
+++ b/src/tests/unit/fixtures/apache/generated/SharedService.ts
@@ -368,6 +368,7 @@ export class Processor extends SharedServiceBase.Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
+            console.error("Unexpected exception while handling getUnion: ", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("getUnion", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);
@@ -393,6 +394,7 @@ export class Processor extends SharedServiceBase.Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
+            console.error("Unexpected exception while handling getEnum: ", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("getEnum", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);

--- a/src/tests/unit/fixtures/apache/generated/SharedServiceBase.ts
+++ b/src/tests/unit/fixtures/apache/generated/SharedServiceBase.ts
@@ -226,6 +226,7 @@ export class Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
+            console.error("Unexpected exception while handling getStruct: ", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("getStruct", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);

--- a/src/tests/unit/fixtures/apache/generated/com/test/calculator/Calculator.ts
+++ b/src/tests/unit/fixtures/apache/generated/com/test/calculator/Calculator.ts
@@ -2603,6 +2603,7 @@ export class Processor extends __ROOT_NAMESPACE__.SharedService.Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
+            console.error("Unexpected exception while handling ping: ", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("ping", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);
@@ -2638,6 +2639,7 @@ export class Processor extends __ROOT_NAMESPACE__.SharedService.Processor {
                 return;
             }
             else {
+                console.error("Unexpected exception while handling add: ", err);
                 const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, err.message);
                 output.writeMessageBegin("add", thrift.Thrift.MessageType.EXCEPTION, requestId);
                 result.write(output);
@@ -2674,6 +2676,7 @@ export class Processor extends __ROOT_NAMESPACE__.SharedService.Processor {
                 return;
             }
             else {
+                console.error("Unexpected exception while handling addInt64: ", err);
                 const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, err.message);
                 output.writeMessageBegin("addInt64", thrift.Thrift.MessageType.EXCEPTION, requestId);
                 result.write(output);
@@ -2701,6 +2704,7 @@ export class Processor extends __ROOT_NAMESPACE__.SharedService.Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
+            console.error("Unexpected exception while handling addWithContext: ", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("addWithContext", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);
@@ -2736,6 +2740,7 @@ export class Processor extends __ROOT_NAMESPACE__.SharedService.Processor {
                 return;
             }
             else {
+                console.error("Unexpected exception while handling calculate: ", err);
                 const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, err.message);
                 output.writeMessageBegin("calculate", thrift.Thrift.MessageType.EXCEPTION, requestId);
                 result.write(output);
@@ -2763,6 +2768,7 @@ export class Processor extends __ROOT_NAMESPACE__.SharedService.Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
+            console.error("Unexpected exception while handling echoBinary: ", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("echoBinary", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);
@@ -2789,6 +2795,7 @@ export class Processor extends __ROOT_NAMESPACE__.SharedService.Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
+            console.error("Unexpected exception while handling echoString: ", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("echoString", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);
@@ -2815,6 +2822,7 @@ export class Processor extends __ROOT_NAMESPACE__.SharedService.Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
+            console.error("Unexpected exception while handling checkName: ", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("checkName", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);
@@ -2841,6 +2849,7 @@ export class Processor extends __ROOT_NAMESPACE__.SharedService.Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
+            console.error("Unexpected exception while handling checkOptional: ", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("checkOptional", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);
@@ -2867,6 +2876,7 @@ export class Processor extends __ROOT_NAMESPACE__.SharedService.Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
+            console.error("Unexpected exception while handling mapOneList: ", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("mapOneList", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);
@@ -2893,6 +2903,7 @@ export class Processor extends __ROOT_NAMESPACE__.SharedService.Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
+            console.error("Unexpected exception while handling mapValues: ", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("mapValues", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);
@@ -2919,6 +2930,7 @@ export class Processor extends __ROOT_NAMESPACE__.SharedService.Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
+            console.error("Unexpected exception while handling listToMap: ", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("listToMap", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);
@@ -2944,6 +2956,7 @@ export class Processor extends __ROOT_NAMESPACE__.SharedService.Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
+            console.error("Unexpected exception while handling fetchThing: ", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("fetchThing", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);
@@ -2969,6 +2982,7 @@ export class Processor extends __ROOT_NAMESPACE__.SharedService.Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
+            console.error("Unexpected exception while handling fetchMap: ", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("fetchMap", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);
@@ -2994,6 +3008,7 @@ export class Processor extends __ROOT_NAMESPACE__.SharedService.Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
+            console.error("Unexpected exception while handling zip: ", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("zip", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);

--- a/src/tests/unit/fixtures/apache/i64_service.solution.ts
+++ b/src/tests/unit/fixtures/apache/i64_service.solution.ts
@@ -255,6 +255,7 @@ export class Processor {
             output.flush();
             return;
         }).catch((err: Error): void => {
+            console.error("Unexpected exception while handling add: ", err);
             const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("add", thrift.Thrift.MessageType.EXCEPTION, requestId);
             result.write(output);

--- a/src/tests/unit/fixtures/apache/return_service.solution.ts
+++ b/src/tests/unit/fixtures/apache/return_service.solution.ts
@@ -302,6 +302,7 @@ export class Processor {
                 return;
             }
             else {
+                console.error("Unexpected exception while handling ping: ", err);
                 const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, err.message);
                 output.writeMessageBegin("ping", thrift.Thrift.MessageType.EXCEPTION, requestId);
                 result.write(output);

--- a/src/tests/unit/fixtures/apache/throws_multi_service.solution.ts
+++ b/src/tests/unit/fixtures/apache/throws_multi_service.solution.ts
@@ -483,6 +483,7 @@ export class Processor {
                 return;
             }
             else {
+                console.error("Unexpected exception while handling peg: ", err);
                 const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, err.message);
                 output.writeMessageBegin("peg", thrift.Thrift.MessageType.EXCEPTION, requestId);
                 result.write(output);

--- a/src/tests/unit/fixtures/apache/throws_service.solution.ts
+++ b/src/tests/unit/fixtures/apache/throws_service.solution.ts
@@ -262,6 +262,7 @@ export class Processor {
                 return;
             }
             else {
+                console.error("Unexpected exception while handling ping: ", err);
                 const result: thrift.Thrift.TApplicationException = new thrift.Thrift.TApplicationException(thrift.Thrift.TApplicationExceptionType.UNKNOWN, err.message);
                 output.writeMessageBegin("ping", thrift.Thrift.MessageType.EXCEPTION, requestId);
                 result.write(output);

--- a/src/tests/unit/fixtures/thrift-server/annotations_service.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/annotations_service.solution.ts
@@ -777,6 +777,7 @@ export class Processor<Context = any> extends thrift.ThriftProcessor<Context, IH
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling getUser: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("getUser", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -801,6 +802,7 @@ export class Processor<Context = any> extends thrift.ThriftProcessor<Context, IH
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling saveUser: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("saveUser", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -824,6 +826,7 @@ export class Processor<Context = any> extends thrift.ThriftProcessor<Context, IH
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling ping: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("ping", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);

--- a/src/tests/unit/fixtures/thrift-server/basic_service.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/basic_service.solution.ts
@@ -765,6 +765,7 @@ export class Processor<Context = any> extends thrift.ThriftProcessor<Context, IH
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling getUser: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("getUser", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -789,6 +790,7 @@ export class Processor<Context = any> extends thrift.ThriftProcessor<Context, IH
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling saveUser: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("saveUser", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -812,6 +814,7 @@ export class Processor<Context = any> extends thrift.ThriftProcessor<Context, IH
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling ping: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("ping", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);

--- a/src/tests/unit/fixtures/thrift-server/basic_service.strict_union.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/basic_service.strict_union.solution.ts
@@ -610,6 +610,7 @@ export class Processor<Context = any> extends thrift.ThriftProcessor<Context, IH
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling getUser: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("getUser", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -633,6 +634,7 @@ export class Processor<Context = any> extends thrift.ThriftProcessor<Context, IH
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling ping: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("ping", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/SharedService.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/SharedService.ts
@@ -488,6 +488,7 @@ export class Processor<Context = any> extends SharedServiceBase.Processor<Contex
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling getUnion: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("getUnion", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -511,6 +512,7 @@ export class Processor<Context = any> extends SharedServiceBase.Processor<Contex
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling getEnum: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("getEnum", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/SharedServiceBase.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/SharedServiceBase.ts
@@ -295,6 +295,7 @@ export class Processor<Context = any> extends thrift.ThriftProcessor<Context, IH
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling getStruct: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("getStruct", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);

--- a/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/calculator/Calculator.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated-strict/com/test/calculator/Calculator.ts
@@ -3453,6 +3453,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling ping: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("ping", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3485,6 +3486,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
                 return output.flush();
             }
             else {
+                console.error("Unexpected exception while handling add: ", err);
                 const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
                 output.writeMessageBegin("add", thrift.MessageType.EXCEPTION, requestId);
                 thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3518,6 +3520,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
                 return output.flush();
             }
             else {
+                console.error("Unexpected exception while handling addInt64: ", err);
                 const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
                 output.writeMessageBegin("addInt64", thrift.MessageType.EXCEPTION, requestId);
                 thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3543,6 +3546,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling addWithContext: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("addWithContext", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3575,6 +3579,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
                 return output.flush();
             }
             else {
+                console.error("Unexpected exception while handling calculate: ", err);
                 const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
                 output.writeMessageBegin("calculate", thrift.MessageType.EXCEPTION, requestId);
                 thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3600,6 +3605,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling echoBinary: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("echoBinary", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3624,6 +3630,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling echoString: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("echoString", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3648,6 +3655,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling checkName: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("checkName", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3672,6 +3680,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling checkOptional: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("checkOptional", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3696,6 +3705,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling mapOneList: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("mapOneList", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3720,6 +3730,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling mapValues: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("mapValues", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3744,6 +3755,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling listToMap: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("listToMap", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3767,6 +3779,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling fetchThing: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("fetchThing", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3790,6 +3803,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling fetchMap: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("fetchMap", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3813,6 +3827,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling zip: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("zip", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);

--- a/src/tests/unit/fixtures/thrift-server/generated/SharedService.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/SharedService.ts
@@ -488,6 +488,7 @@ export class Processor<Context = any> extends SharedServiceBase.Processor<Contex
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling getUnion: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("getUnion", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -511,6 +512,7 @@ export class Processor<Context = any> extends SharedServiceBase.Processor<Contex
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling getEnum: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("getEnum", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);

--- a/src/tests/unit/fixtures/thrift-server/generated/SharedServiceBase.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/SharedServiceBase.ts
@@ -295,6 +295,7 @@ export class Processor<Context = any> extends thrift.ThriftProcessor<Context, IH
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling getStruct: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("getStruct", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);

--- a/src/tests/unit/fixtures/thrift-server/generated/com/test/calculator/Calculator.ts
+++ b/src/tests/unit/fixtures/thrift-server/generated/com/test/calculator/Calculator.ts
@@ -3453,6 +3453,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling ping: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("ping", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3485,6 +3486,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
                 return output.flush();
             }
             else {
+                console.error("Unexpected exception while handling add: ", err);
                 const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
                 output.writeMessageBegin("add", thrift.MessageType.EXCEPTION, requestId);
                 thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3518,6 +3520,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
                 return output.flush();
             }
             else {
+                console.error("Unexpected exception while handling addInt64: ", err);
                 const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
                 output.writeMessageBegin("addInt64", thrift.MessageType.EXCEPTION, requestId);
                 thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3543,6 +3546,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling addWithContext: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("addWithContext", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3575,6 +3579,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
                 return output.flush();
             }
             else {
+                console.error("Unexpected exception while handling calculate: ", err);
                 const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
                 output.writeMessageBegin("calculate", thrift.MessageType.EXCEPTION, requestId);
                 thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3600,6 +3605,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling echoBinary: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("echoBinary", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3624,6 +3630,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling echoString: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("echoString", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3648,6 +3655,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling checkName: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("checkName", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3672,6 +3680,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling checkOptional: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("checkOptional", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3696,6 +3705,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling mapOneList: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("mapOneList", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3720,6 +3730,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling mapValues: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("mapValues", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3744,6 +3755,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling listToMap: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("listToMap", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3767,6 +3779,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling fetchThing: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("fetchThing", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3790,6 +3803,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling fetchMap: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("fetchMap", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -3813,6 +3827,7 @@ export class Processor<Context = any> extends __ROOT_NAMESPACE__.SharedService.P
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling zip: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("zip", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);

--- a/src/tests/unit/fixtures/thrift-server/i64_service.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/i64_service.solution.ts
@@ -566,6 +566,7 @@ export class Processor<Context = any> extends thrift.ThriftProcessor<Context, IH
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling peg: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("peg", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
@@ -590,6 +591,7 @@ export class Processor<Context = any> extends thrift.ThriftProcessor<Context, IH
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling pong: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("pong", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);

--- a/src/tests/unit/fixtures/thrift-server/resolved_field_service.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/resolved_field_service.solution.ts
@@ -274,6 +274,7 @@ export class Processor<Context = any> extends thrift.ThriftProcessor<Context, IH
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling ping: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("ping", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);

--- a/src/tests/unit/fixtures/thrift-server/throws_multi_service.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/throws_multi_service.solution.ts
@@ -641,6 +641,7 @@ export class Processor<Context = any> extends thrift.ThriftProcessor<Context, IH
                 return output.flush();
             }
             else {
+                console.error("Unexpected exception while handling peg: ", err);
                 const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
                 output.writeMessageBegin("peg", thrift.MessageType.EXCEPTION, requestId);
                 thrift.TApplicationExceptionCodec.encode(result, output);

--- a/src/tests/unit/fixtures/thrift-server/throws_service.solution.ts
+++ b/src/tests/unit/fixtures/thrift-server/throws_service.solution.ts
@@ -600,6 +600,7 @@ export class Processor<Context = any> extends thrift.ThriftProcessor<Context, IH
                 return output.flush();
             }
             else {
+                console.error("Unexpected exception while handling peg: ", err);
                 const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
                 output.writeMessageBegin("peg", thrift.MessageType.EXCEPTION, requestId);
                 thrift.TApplicationExceptionCodec.encode(result, output);
@@ -625,6 +626,7 @@ export class Processor<Context = any> extends thrift.ThriftProcessor<Context, IH
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling pong: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("pong", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);


### PR DESCRIPTION
BACKGROUND

Two kinds of exceptions can be thrown by a handler processing a Thrift request:

- Those that are defined as `exceptions` in a .thrift file. The server serializes them and sends them to the client. Clients should expect them to happen from time to time and should handle them gracefully.
- Non-Thrift exceptions: when the server experiences an unhandled error and an exception not defined in a .thrift file is throw out of the handler function. The server has catch-all exception handling that returns a `TApplicationException` to the client containing the message from the exception.

THIS CHANGE

I modifed the code that generates the server processor to include a console.error() statement that logs exception messages and stack traces when a handler throws a non-Thrift exception. Previously there was no server-side logging for non-Thrift exceptions. The message was sent to the client and the stack trace was discarded entirely. This is not sufficient. Even if you have the exception message received by the client that may not be enough to determine where the error happened. And if you don't control the client then you're REALLY out of luck.

There are no other calls to console.log() or console.error() in the generated code. It could be argued that it's bad form for the generated code to use console.error() since it's sort of like a library, but I think it's more important to log the exception. A better solution might be to allow server implementors to provide a callback function for logging, but I leave that as an exercise for a future developer.

I updated both the Apache code and the thrift-server code, and the tests for both.

Here's the diff of a `ping` function generated for thrift-server before and after this change:
```
--- before	2020-07-27 08:05:20.000000000 -0400
+++ after	2020-07-27 08:05:13.000000000 -0400
@@ -1,23 +1,24 @@
     public process_ping(requestId: number, input: thrift.TProtocol, output: thrift.TProtocol, context: Context): Promise<Buffer> {
         return new Promise<string>((resolve, reject): void => {
             try {
                 input.readMessageEnd();
                 resolve(this._handler.ping(context));
             }
             catch (err) {
                 reject(err);
             }
         }).then((data: string): Buffer => {
             const result: IPing__ResultArgs = { success: data };
             output.writeMessageBegin("ping", thrift.MessageType.REPLY, requestId);
             Ping__ResultCodec.encode(result, output);
             output.writeMessageEnd();
             return output.flush();
         }).catch((err: Error): Buffer => {
+            console.error("Unexpected exception while handling ping: ", err);
             const result: thrift.TApplicationException = new thrift.TApplicationException(thrift.TApplicationExceptionType.UNKNOWN, err.message);
             output.writeMessageBegin("ping", thrift.MessageType.EXCEPTION, requestId);
             thrift.TApplicationExceptionCodec.encode(result, output);
             output.writeMessageEnd();
             return output.flush();
         });
     }
```