### PR TITLE
Gerard option to promote function field to param

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "@creditkarma/thrift-typescript",
-    "version": "3.7.6",
-    "description": "Generate TypeScript from Thrift IDL files",
+    "name": "@outlook/thrift-typescript",
+    "version": "3.7.7",
+    "description": "Generate TypeScript from Thrift IDL files - forked in kivarsha/thrift-typescript",
     "main": "./dist/main/index.js",
     "types": "./dist/main/index.d.ts",
     "bin": {
@@ -36,10 +36,11 @@
         "rpc"
     ],
     "author": "Credit Karma",
+    "contributors": ["Microsoft Corporation"],
     "license": "Apache-2.0",
     "repository": {
         "type": "git",
-        "url": "https://github.com/creditkarma/thrift-typescript"
+        "url": "https://github.com/kivarsha/thrift-typescript"
     },
     "dependencies": {
         "@creditkarma/thrift-parser": "^1.2.0",

--- a/src/main/bin/resolveOptions.ts
+++ b/src/main/bin/resolveOptions.ts
@@ -84,6 +84,16 @@ export function resolveOptions(args: Array<string>): IMakeOptions {
                 index += 1
                 break
 
+            case '--omitProtocolReaders':
+                options.omitProtocolReaders = true
+                index += 1
+                break
+
+            case '--omitThriftLibImport':
+                options.omitThriftLibImport = true
+                index += 1
+                break
+
             default:
                 if (next.startsWith('--')) {
                     throw new Error(

--- a/src/main/bin/resolveOptions.ts
+++ b/src/main/bin/resolveOptions.ts
@@ -94,6 +94,11 @@ export function resolveOptions(args: Array<string>): IMakeOptions {
                 index += 1
                 break
 
+            case '--useInterfacesWithFunctions':
+                options.useInterfacesWithFunctions = true
+                index += 1
+                break
+
             default:
                 if (next.startsWith('--')) {
                     throw new Error(

--- a/src/main/bin/resolveOptions.ts
+++ b/src/main/bin/resolveOptions.ts
@@ -99,6 +99,11 @@ export function resolveOptions(args: Array<string>): IMakeOptions {
                 index += 1
                 break
 
+            case '--useStringLiteralsForEnums':
+                options.useStringLiteralsForEnums = true
+                index += 1
+                break
+
             default:
                 if (next.startsWith('--')) {
                     throw new Error(

--- a/src/main/defaults.ts
+++ b/src/main/defaults.ts
@@ -18,6 +18,7 @@ export const DEFAULT_OPTIONS: IMakeOptions = {
     withNameField: false,
     omitProtocolReaders: false,
     omitThriftLibImport: false,
+    useInterfacesWithFunctions: false,
 }
 
 export function defaultLibrary(options: Partial<IMakeOptions>): string {

--- a/src/main/defaults.ts
+++ b/src/main/defaults.ts
@@ -16,6 +16,8 @@ export const DEFAULT_OPTIONS: IMakeOptions = {
     strictUnionsComplexNames: false,
     fallbackNamespace: 'java',
     withNameField: false,
+    omitProtocolReaders: false,
+    omitThriftLibImport: false,
 }
 
 export function defaultLibrary(options: Partial<IMakeOptions>): string {

--- a/src/main/defaults.ts
+++ b/src/main/defaults.ts
@@ -19,6 +19,7 @@ export const DEFAULT_OPTIONS: IMakeOptions = {
     omitProtocolReaders: false,
     omitThriftLibImport: false,
     useInterfacesWithFunctions: false,
+    useStringLiteralsForEnums: false,
 }
 
 export function defaultLibrary(options: Partial<IMakeOptions>): string {

--- a/src/main/render/apache/enum.ts
+++ b/src/main/render/apache/enum.ts
@@ -2,6 +2,7 @@ import * as ts from 'typescript'
 
 import { EnumDefinition, EnumMember } from '@creditkarma/thrift-parser'
 
+import { IRenderState } from '../../types'
 import { renderIntConstant } from './values'
 
 /**
@@ -19,7 +20,10 @@ import { renderIntConstant } from './values'
  *   TWO
  * }
  */
-export function renderEnum(node: EnumDefinition): ts.Statement {
+export function renderEnum(
+    node: EnumDefinition,
+    state: IRenderState,
+): ts.Statement {
     return ts.createEnumDeclaration(
         undefined, // decorators
         [ts.createToken(ts.SyntaxKind.ExportKeyword)], // modifiers
@@ -28,7 +32,9 @@ export function renderEnum(node: EnumDefinition): ts.Statement {
             return ts.createEnumMember(
                 field.name.value,
                 field.initializer !== null
-                    ? renderIntConstant(field.initializer)
+                    ? state.options.useStringLiteralsForEnums
+                        ? ts.createLiteral(field.name.value)
+                        : renderIntConstant(field.initializer)
                     : undefined,
             )
         }), // enum members

--- a/src/main/render/apache/function.ts
+++ b/src/main/render/apache/function.ts
@@ -1,0 +1,62 @@
+import * as ts from 'typescript'
+
+import {
+    FieldDefinition,
+    InterfaceWithFields,
+} from '@creditkarma/thrift-parser'
+
+import { IRenderState } from '../../types'
+import { createArgsParameterForStruct } from './struct'
+import { renderValue } from './values'
+
+export function functionNameForClass(statement: InterfaceWithFields): string {
+    return `create${statement.name.value}`
+}
+
+function interfaceConstruction(
+    statement: InterfaceWithFields,
+    state: IRenderState,
+): ts.Block {
+    return ts.createBlock(
+        [
+            ts.createReturn(
+                ts.createObjectLiteral(
+                    statement.fields.map((field: FieldDefinition) => {
+                        const defaultValue =
+                            field.defaultValue !== null
+                                ? renderValue(
+                                      field.fieldType,
+                                      field.defaultValue,
+                                      state,
+                                  )
+                                : ts.createIdentifier(
+                                      `args.${field.name.value}`,
+                                  )
+                        return ts.createPropertyAssignment(
+                            ts.createIdentifier(field.name.value),
+                            defaultValue,
+                        )
+                    }),
+                    true,
+                ),
+            ),
+        ],
+        true,
+    )
+}
+
+export function renderFunction(
+    statement: InterfaceWithFields,
+    state: IRenderState,
+): ts.FunctionDeclaration {
+    return ts.createFunctionDeclaration(
+        undefined,
+        [ts.createToken(ts.SyntaxKind.ExportKeyword)],
+        undefined,
+        functionNameForClass(statement),
+        undefined,
+        createArgsParameterForStruct(statement),
+        ts.createTypeReferenceNode(statement.name.value, undefined),
+        interfaceConstruction(statement, state),
+    )
+}

--- a/src/main/render/apache/identifiers.ts
+++ b/src/main/render/apache/identifiers.ts
@@ -2,6 +2,10 @@ import * as ts from 'typescript'
 
 export * from '../shared/identifiers'
 
+export const DEFAULT_IDENTIFIERS = {
+    Exception: ts.createIdentifier('Error'),
+}
+
 export const THRIFT_IDENTIFIERS = {
     TMessage: ts.createIdentifier('thrift.TMessage'),
     TField: ts.createIdentifier('thrift.TField'),

--- a/src/main/render/apache/index.ts
+++ b/src/main/render/apache/index.ts
@@ -13,7 +13,7 @@ import {
 
 import { renderException as _renderException } from './exception'
 
-import { renderInterface } from './interface'
+import { renderFullInterface, renderInterface } from './interface'
 
 import {
     renderArgsStruct,
@@ -38,6 +38,7 @@ import { renderUnion as _renderUnion } from './union'
 
 import { IRenderer, IRenderState } from '../../types'
 import { renderIndex } from '../shared'
+import { renderFunction } from './function'
 import { typeNodeForFieldType } from './types'
 
 export function renderImports(
@@ -84,7 +85,18 @@ export function renderStruct(
     statement: StructDefinition,
     state: IRenderState,
 ): Array<ts.Statement> {
-    return [renderInterface(statement, state), _renderStruct(statement, state)]
+    if (state.options.useInterfacesWithFunctions) {
+        return [
+            renderInterface(statement, state),
+            renderFullInterface(statement, state),
+            renderFunction(statement, state),
+        ]
+    } else {
+        return [
+            renderInterface(statement, state),
+            _renderStruct(statement, state),
+        ]
+    }
 }
 
 export function renderException(

--- a/src/main/render/apache/index.ts
+++ b/src/main/render/apache/index.ts
@@ -48,7 +48,7 @@ export function renderImports(
         ..._renderIncludes(statements, state),
     ]
 
-    if (statementsUseThrift(statements)) {
+    if (statementsUseThrift(statements) && !state.options.omitThriftLibImport) {
         includes.unshift(renderThriftImports(state.options.library))
     }
 

--- a/src/main/render/apache/index.ts
+++ b/src/main/render/apache/index.ts
@@ -78,7 +78,7 @@ export function renderEnum(
     statement: EnumDefinition,
     state: IRenderState,
 ): Array<ts.Statement> {
-    return [_renderEnum(statement)]
+    return [_renderEnum(statement, state)]
 }
 
 export function renderStruct(

--- a/src/main/render/apache/struct/create.ts
+++ b/src/main/render/apache/struct/create.ts
@@ -39,6 +39,15 @@ export function renderStruct(
         state,
     )
 
+    let nodeFields = node.fields
+
+    if (state.options.useInterfacesWithFunctions) {
+        // if default value exists, no need to set in args
+        nodeFields = nodeFields.filter((field: FieldDefinition) => {
+            return field.defaultValue == null
+        })
+    }
+
     /**
      * After creating the properties on our class for the struct fields we must create
      * a constructor that knows how to assign these values based on a passed args.
@@ -52,14 +61,16 @@ export function renderStruct(
      * If a required argument is not on the passed 'args' argument we need to throw on error.
      * Optional fields we must allow to be null or undefined.
      */
-    const fieldAssignments: Array<ts.IfStatement> = node.fields.map(
-        (value: FieldDefinition) => {
+    const fieldAssignments: Array<ts.IfStatement> = nodeFields
+        .filter((field: FieldDefinition) => {
+            return field.defaultValue == null
+        })
+        .map((value: FieldDefinition) => {
             return createFieldAssignment(
                 value,
                 state.options.omitThriftLibImport,
             )
-        },
-    )
+        })
 
     const argsParameter: Array<
         ts.ParameterDeclaration

--- a/src/main/render/apache/utils.ts
+++ b/src/main/render/apache/utils.ts
@@ -10,6 +10,7 @@ import { TApplicationException, TProtocolException } from './types'
 
 import {
     APPLICATION_EXCEPTION,
+    DEFAULT_IDENTIFIERS,
     PROTOCOL_EXCEPTION,
     THRIFT_IDENTIFIERS,
 } from './identifiers'
@@ -24,6 +25,16 @@ export function createProtocolException(
     const errType = PROTOCOL_EXCEPTION[type]
     const errArgs = [errType, ts.createLiteral(message)]
     return ts.createNew(errCtor, undefined, errArgs)
+}
+
+export function createDefaultException(message: string): ts.NewExpression {
+    const errCtor = DEFAULT_IDENTIFIERS.Exception
+    const errArgs = [ts.createLiteral(message)]
+    return ts.createNew(errCtor, undefined, errArgs)
+}
+
+export function throwDefaultException(message: string): ts.ThrowStatement {
+    return ts.createThrow(createDefaultException(message))
 }
 
 export function throwProtocolException(

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -164,6 +164,9 @@ export interface IMakeOptions {
 
     // Omit thrift library imports
     omitThriftLibImport: boolean
+
+    // replace classes with interfaces + functions
+    useInterfacesWithFunctions: boolean
 }
 
 export interface IThriftFiles {

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -167,6 +167,9 @@ export interface IMakeOptions {
 
     // replace classes with interfaces + functions
     useInterfacesWithFunctions: boolean
+
+    // replace enum int values with string literals
+    useStringLiteralsForEnums: boolean
 }
 
 export interface IThriftFiles {

--- a/src/main/types.ts
+++ b/src/main/types.ts
@@ -158,6 +158,12 @@ export interface IMakeOptions {
 
     // Should we render the __name field on struct-like objects
     withNameField: boolean
+
+    // Should we just create the constructor without the protocol readers?
+    omitProtocolReaders: boolean
+
+    // Omit thrift library imports
+    omitThriftLibImport: boolean
 }
 
 export interface IThriftFiles {


### PR DESCRIPTION
These changes are to help reduce overhead when binding to structs' generated *Args interfaces.  

A package cmd line option param was added which will optionally exclude a given field/property type-name from the typescript generated Args interface and also change the signature of the generated function by promoting that property as a separate function parameter (because the property will no longer be contained in the Args object function parameter). 

This new option is only applicable when --useInterfacesWithFunctions param is also passed in.

Example, when passing the below param and property type-name,  if a Args interface includes this property then it would be excluded from Args and promoted to be a parameter in the associated function definition.
     **--functionsFieldPromotion UTCommonHVAProperties**